### PR TITLE
Add support for ORCA normal mode model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,6 @@ UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 [compat]
 AcousticsToolbox_jll = "2025.6.18"
 Printf = "1"
-SimpleDiffEq = "1.12.0"
+SimpleDiffEq = "1.12"
 UnderwaterAcoustics = "0.5"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,6 @@ UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
 UnderwaterAcoustics = "0.4"
-AcousticsToolbox_jll = "2020.11.4, 2022.4.20, 2024.12.25"
+AcousticsToolbox_jll = "2025.6.18"
 Printf = "1"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
-AcousticsToolbox_jll = "2025.6.18"
+AcousticsToolbox_jll = "2025.9.6"
 Printf = "1"
-UnderwaterAcoustics = "0.5"
+UnderwaterAcoustics = "0.6"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,12 @@ version = "0.6.0"
 [deps]
 AcousticsToolbox_jll = "6380ca6f-c335-511c-b45e-8a1ed8902ca7"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SimpleDiffEq = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
 UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
-UnderwaterAcoustics = "0.5"
 AcousticsToolbox_jll = "2025.6.18"
 Printf = "1"
+SimpleDiffEq = "1.12.0"
+UnderwaterAcoustics = "0.5"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,10 @@ version = "0.6.0"
 [deps]
 AcousticsToolbox_jll = "6380ca6f-c335-511c-b45e-8a1ed8902ca7"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-SimpleDiffEq = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
 UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
 AcousticsToolbox_jll = "2025.6.18"
 Printf = "1"
-SimpleDiffEq = "1.12"
 UnderwaterAcoustics = "0.5"
 julia = "1.9"

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@
 
 # AcousticsToolbox
 
-This package provides a Julia wrapper to the [OALIB](http://oalib.hlsresearch.com/AcousticsToolbox/) acoustic propagation modeling toolbox,
-making it available for use with [`UnderwaterAcoustics.jl`](https://github.com/org-arl/UnderwaterAcoustics.jl).
+This package provides a Julia wrapper to the [OALIB](http://oalib.hlsresearch.com/AcousticsToolbox/) acoustic propagation modeling toolbox
+(and other related tools), making it available for use with [`UnderwaterAcoustics.jl`](https://github.com/org-arl/UnderwaterAcoustics.jl).
 
-Currently, only two of the OALIB models are supported:
+Currently, the following models are supported:
 
-- Bellhop 2D Gaussian beam tracer (almost complete support)
-- Kraken 2D normal mode model (partial support)
+- Bellhop 2D Gaussian beam tracer
+- Kraken 2D normal mode model
+- Orca 2D normal mode model
 
-For information on how to use the models, see [documentation](https://org-arl.github.io/UnderwaterAcoustics.jl/bellhop.html).
+For information on how to use the models, see [documentation](https://org-arl.github.io/UnderwaterAcoustics.jl/).
 
 ## Contributing
 
@@ -23,3 +24,4 @@ Contributions in the form of bug reports, feature requests, ideas/suggestions, b
 The scopes active in this repository are:
 - **bellhop**: Bellhop
 - **kraken**: Kraken
+- **orca**: Orca

--- a/src/AcousticsToolbox.jl
+++ b/src/AcousticsToolbox.jl
@@ -11,6 +11,7 @@ using Printf
 
 include("bellhop.jl")
 include("kraken.jl")
+include("orca.jl")
 include("common.jl")
 
 end # module

--- a/src/bellhop.jl
+++ b/src/bellhop.jl
@@ -16,7 +16,7 @@ struct Bellhop{T} <: AbstractRayPropagationModel
     -π/2 ≤ min_angle ≤ π/2 || error("min_angle should be between -π/2 and π/2")
     -π/2 ≤ max_angle ≤ π/2 || error("max_angle should be between -π/2 and π/2")
     min_angle < max_angle || error("max_angle should be more than min_angle")
-    beam_type ∈ (:geometric, :gaussian) || error("unknown beam_type type")
+    beam_type ∈ (:geometric, :gaussian) || error("Unknown beam_type type")
     new{typeof(env)}(env, max(nbeams, 0), Float32(in_units(u"rad", min_angle)), Float32(in_units(u"rad", max_angle)), beam_type, beam_shift, debug)
   end
 end
@@ -141,7 +141,7 @@ end
 function _check_env(::Type{Bellhop}, env)
   env.seabed isa FluidBoundary || env.seabed isa ElasticBoundary || error("seabed must be a FluidBoundary or ElasticBoundary")
   env.surface isa FluidBoundary || error("surface must be a FluidBoundary")
-  is_range_dependent(env.soundspeed) && error("range-dependent soundspeed not supported")
+  is_range_dependent(env.soundspeed) && error("Range-dependent soundspeed not supported")
   mktempdir(prefix="bellhop_") do dirname
     try
       _bellhop(dirname, false)

--- a/src/bellhop.jl
+++ b/src/bellhop.jl
@@ -47,11 +47,11 @@ function UnderwaterAcoustics.arrivals(pm::Bellhop, tx1::AbstractAcousticSource, 
   mktempdir(prefix="bellhop_") do dirname
     nbeams = pm.nbeams
     nbeams == 0 && (nbeams = round(Int, (pm.max_angle - pm.min_angle) / deg2rad(0.05)) + 1)
-    _write_env(pm, [tx1], [rx1], dirname; nbeams, taskcode='A')
+    _write_env(pm, tx1, [rx1], dirname; nbeams, taskcode='A')
     _bellhop(dirname, pm.debug)
     arr = _read_arr(joinpath(dirname, "model.arr"))
     if paths
-      _write_env(pm, [tx1], [rx1], dirname; nbeams, taskcode='E')
+      _write_env(pm, tx1, [rx1], dirname; nbeams, taskcode='E')
       _bellhop(dirname, pm.debug)
       arr2 = _read_rays(joinpath(dirname, "model.ray"))
       for i ∈ eachindex(arr)
@@ -77,7 +77,7 @@ function UnderwaterAcoustics.acoustic_field(pm::Bellhop, tx1::AbstractAcousticSo
     error("Unknown mode :" * string(mode))
   end
   fld = mktempdir(prefix="bellhop_") do dirname
-    xrev, zrev = _write_env(pm, [tx1], rx, dirname; taskcode)
+    xrev, zrev = _write_env(pm, tx1, rx, dirname; taskcode)
     _bellhop(dirname, pm.debug)
     _read_shd(joinpath(dirname, "model.shd"); xrev, zrev)
   end
@@ -95,7 +95,7 @@ function UnderwaterAcoustics.acoustic_field(pm::Bellhop, tx1::AbstractAcousticSo
     error("Unknown mode :" * string(mode))
   end
   fld = mktempdir(prefix="bellhop_") do dirname
-    _write_env(pm, [tx1], [rx1], dirname; taskcode)
+    _write_env(pm, tx1, [rx1], dirname; taskcode)
     _bellhop(dirname, pm.debug)
     _read_shd(joinpath(dirname, "model.shd"))[1]
   end
@@ -110,7 +110,7 @@ Compute ray trace for a single transmitter.
 """
 function rays(pm::Bellhop, tx1::AbstractAcousticSource, max_range::Real, nbeams::Int=pm.nbeams)
   mktempdir(prefix="bellhop_") do dirname
-    _write_env(pm, [tx1], [AcousticReceiver(max_range, 0)], dirname; nbeams, taskcode='R')
+    _write_env(pm, tx1, [AcousticReceiver(max_range, 0)], dirname; nbeams, taskcode='R')
     _bellhop(dirname, pm.debug)
     _read_rays(joinpath(dirname, "model.ray"))
   end
@@ -144,7 +144,7 @@ function _check_env(::Type{Bellhop}, env)
   is_range_dependent(env.soundspeed) && error("range-dependent soundspeed not supported")
   mktempdir(prefix="bellhop_") do dirname
     try
-      bellhop(dirname, false)
+      _bellhop(dirname, false)
     catch e
       e isa ExecError && e.details == ["Unable to execute Bellhop"] && throw(e)
     end

--- a/src/common.jl
+++ b/src/common.jl
@@ -52,7 +52,7 @@ function _write_env(pm, tx1, rx, dirname; nbeams=0, taskcode=' ')
     end
     ssp = env.soundspeed
     sspi = 'C'
-    ssp isa SampledFieldZ && ssp.interp === :cubic && (sspi = 'S')
+    ssp isa SampledFieldZ && ssp.interp === CubicSpline() && (sspi = 'S')
     surf = env.surface === RigidBoundary ? 'R' : env.surface === PressureReleaseBoundary ? 'V' : 'A'
     print(io, "'", sspi, surf, "WF")  # bottom attenuation in dB/wavelength, Francois-Garrison volume attenuation
     pm isa Kraken && pm.robust && print(io, ".")
@@ -177,7 +177,7 @@ function _create_alt_bathy_file(filename, data, func, maxr, f)
     interp = "L"
     if data isa SampledFieldX
       x = data.xrange
-      data.interp !== :linear && (interp = "C")
+      data.interp !== Linear() && (interp = "C")
     else
       x = range(0.0, maxr; length=_recommend_len(maxr, f))
     end

--- a/src/common.jl
+++ b/src/common.jl
@@ -27,9 +27,9 @@ function _check_err!(err, filename)
   end
 end
 
-function _write_env(pm, tx, rx, dirname; nbeams=0, taskcode=' ')
-  all(location(tx1).x == 0 for tx1 ∈ tx) || error("Transmitters must be at (0, 0, z)")
-  all(location(tx1).y == 0 for tx1 ∈ tx) || error("2D model requires transmitters in the x-z plane")
+function _write_env(pm, tx1, rx, dirname; nbeams=0, taskcode=' ')
+  location(tx1).x == 0 || error("Transmitter must be at (0, 0, z)")
+  location(tx1).y == 0 || error("2D model requires transmitter in the x-z plane")
   all(location(rx1).x >= 0 for rx1 ∈ rx) || error("Receivers must be in the +x halfspace")
   all(location(rx1).y == 0 for rx1 ∈ rx) || error("2D model requires receivers in the x-z plane")
   xrev = false
@@ -39,9 +39,7 @@ function _write_env(pm, tx, rx, dirname; nbeams=0, taskcode=' ')
   filename = joinpath(dirname, "model.env")
   open(filename, "w") do io
     println(io, "'", name, "'")
-    flist = [frequency(tx1) for tx1 ∈ tx]
-    f = sum(flist) / length(flist)
-    maximum(abs, flist .- f) / f > 0.2 && @warn("Source frequency varies by more than 20% from nominal frequency")
+    f = frequency(tx1)
     @printf(io, "%0.6f\n", f)
     nmedia = env.seabed isa MultilayerElasticBoundary ? length(env.seabed.layers) : 1
     println(io, nmedia)
@@ -129,7 +127,7 @@ function _write_env(pm, tx, rx, dirname; nbeams=0, taskcode=' ')
       @printf(io, "%0.6f  %0.6f\n", pm.clow, pm.chigh)
       @printf(io, "%0.6f\n", 1.01 * maxr / 1000.0)
     end
-    _print_array(io, [-location(tx1).z for tx1 ∈ tx])
+    _print_array(io, [-location(tx1).z])
     if length(rx) == 1
       _print_array(io, [-location(rx[1]).z])
       pm isa Kraken || _print_array(io, [maxr / 1000.0])

--- a/src/kraken.jl
+++ b/src/kraken.jl
@@ -124,9 +124,9 @@ end
 function _check_env(::Type{Kraken}, env)
   env.seabed isa FluidBoundary || env.seabed isa ElasticBoundary || env.seabed isa MultilayerElasticBoundary || error("seabed must be a FluidBoundary, ElasticBoundary or MultilayerElasticBoundary")
   env.surface isa FluidBoundary || error("surface must be a FluidBoundary")
-  is_range_dependent(env.soundspeed) && error("range-dependent soundspeed not supported")
-  is_range_dependent(env.altimetry) && error("range-dependent altimetry not supported")
-  is_range_dependent(env.bathymetry) && error("range-dependent bathymetry not supported")
+  is_range_dependent(env.soundspeed) && error("Range-dependent soundspeed not supported")
+  is_range_dependent(env.altimetry) && error("Range-dependent altimetry not supported")
+  is_range_dependent(env.bathymetry) && error("Range-dependent bathymetry not supported")
   mktempdir(prefix="kraken_") do dirname
     try
       _kraken(dirname, false, false)

--- a/src/kraken.jl
+++ b/src/kraken.jl
@@ -61,7 +61,7 @@ function UnderwaterAcoustics.arrivals(pm::Kraken, tx1::AbstractAcousticSource, r
       max_c = 2 * max(max_c, maximum(pm.env.seabed.c))
     end
     rxs = AcousticReceiverGrid2D(rx1.pos.x, range(-D, 0; length=ceil(Int, 10D/λ + 1)))
-    _write_env(pm, [tx1], rxs, dirname)
+    _write_env(pm, tx1, rxs, dirname)
     _kraken(dirname, pm.complex_solver, pm.debug)
     ϕ, kᵣ, depths = _read_mod(pm, dirname)    # read mode shapes
     m, k, v = _read_grp(pm, dirname)          # read group velocity
@@ -90,9 +90,9 @@ function UnderwaterAcoustics.acoustic_field(pm::Kraken, tx1::AbstractAcousticSou
     error("Unknown mode :" * string(mode))
   end
   fld = mktempdir(prefix="kraken_") do dirname
-    xrev, zrev = _write_env(pm, [tx1], rx, dirname)
+    xrev, zrev = _write_env(pm, tx1, rx, dirname)
     _kraken(dirname, pm.complex_solver, pm.debug)
-    _write_flp(pm, [tx1], rx, dirname, mode)
+    _write_flp(pm, tx1, rx, dirname, mode)
     _field(dirname, pm.debug)
     _read_shd(joinpath(dirname, "model.shd"); xrev, zrev)
   end
@@ -109,9 +109,9 @@ function UnderwaterAcoustics.acoustic_field(pm::Kraken, tx1::AbstractAcousticSou
     error("Unknown mode :" * string(mode))
   end
   fld = mktempdir(prefix="bellhop_") do dirname
-    _write_env(pm, [tx1], [rx1], dirname)
+    _write_env(pm, tx1, [rx1], dirname)
     _kraken(dirname, pm.complex_solver, pm.debug)
-    _write_flp(pm, [tx1], [rx1], dirname, mode)
+    _write_flp(pm, tx1, [rx1], dirname, mode)
     _field(dirname, pm.debug)
     _read_shd(joinpath(dirname, "model.shd"))[1]
   end
@@ -129,8 +129,8 @@ function _check_env(::Type{Kraken}, env)
   is_range_dependent(env.bathymetry) && error("range-dependent bathymetry not supported")
   mktempdir(prefix="kraken_") do dirname
     try
-      kraken(dirname, false)
-      krakenc(dirname, false)
+      _kraken(dirname, false, false)
+      _kraken(dirname, true, false)
     catch e
       e isa ExecError && e.details == ["Unable to execute Kraken"] && throw(e)
     end
@@ -179,7 +179,7 @@ function _field(dirname, debug)
   end
 end
 
-function _write_flp(pm::Kraken, tx, rx, dirname, mode)
+function _write_flp(pm::Kraken, tx1, rx, dirname, mode)
   filename = joinpath(dirname, "model.flp")
   open(filename, "w") do io
     println(io, "/")                # take title from modes file
@@ -191,7 +191,7 @@ function _write_flp(pm::Kraken, tx, rx, dirname, mode)
     println(io, "0.0")              # range (km) of first profile
     if length(rx) == 1
       _print_array(io, [location(rx[1]).x / 1000] )       # receiver ranges (km)
-      _print_array(io, [-location(tx1).z for tx1 ∈ tx])   # source depths (m)
+      _print_array(io, [-location(tx1).z])                # source depths (m)
       _print_array(io, [-location(rx[1]).z])              # receiver depths (m)
       _print_array(io, zeros(1))                          # receiver range displacements
     elseif rx isa AcousticReceiverGrid2D
@@ -200,7 +200,7 @@ function _write_flp(pm::Kraken, tx, rx, dirname, mode)
       first(d) > last(d) && (d = reverse(d))
       first(r) > last(r) && (r = reverse(r))
       _print_array(io, r)                                 # receiver ranges (km)
-      _print_array(io, [-location(tx1)[3] for tx1 ∈ tx])  # source depths (m)
+      _print_array(io, [-location(tx1).z])                # source depths (m)
       _print_array(io, d)                                 # receiver depths (m)
       _print_array(io, zeros(length(d)))                  # receiver range displacements
     else

--- a/src/orca.jl
+++ b/src/orca.jl
@@ -1,6 +1,6 @@
 export Orca
 
-const ORCA = Ref{Cmd}(`orca90.exe`) # (AcousticsToolbox_jll.orca90())
+const ORCA = Ref{Cmd}(AcousticsToolbox_jll.orca())
 
 """
 A propagation model based on the ORCA model.
@@ -14,60 +14,60 @@ Base.@kwdef struct Orca{T} <: AbstractRayPropagationModel
   rmax::Float32 = 0.0
   phase_step::Float32 = 1.0
   cutoff::Float32 = 0.0
-  false_bottom::Bool = false
+  false_bottom::Bool = false          # TODO: remove
   mode_depths::Int = 0
+  debug::Bool = false
 end
 
 function _create_orca(pm, tx, rx, dirname)
   name = basename(dirname)
   svp_filename = joinpath(dirname, "orca.svp")
   opt_filename = joinpath(dirname, "orca.opt")
-  out_filename = joinpath(dirname, "orca.out")
   orca_filename = joinpath(dirname, "orca_in")
   open(orca_filename, "w") do io
-    println(io, svp_filename)
-    println(io, opt_filename)
-    println(io, out_filename)
+    println(io, basename(svp_filename))
+    println(io, basename(opt_filename))
+    println(io, "orca.out")
   end
   env = pm.env
   waterdepth = maximum(env.bathymetry)
   open(svp_filename, "w") do io
-    println(io, "*\n3.0 '$name'")
-    @printf(io, "*\n%0.6f 0.0 %0.6f %0.6f 0.0 1.0 1.0\n", env.surface.c, env.surface.ρ / env.density, -in_dBperλ(env.surface.δ))
+    println(io, "*(1)\n2.0 '$name'")
+    @printf(io, "*(2)\n%0.6f 0.0 %0.6f %0.6f 0.0\n", env.surface.c, env.surface.ρ / env.density, -in_dBperλ(env.surface.δ))
     ssp = env.soundspeed
     if is_constant(ssp)
-      println(io, "*\n2 0\n*")
-      @printf(io, "0 %0.6f 1 999\n", value(ssp))
+      println(io, "*(3)\n2 0\n*(4)")
+      @printf(io, "0 %0.6f 1 0\n", value(ssp))
       @printf(io, "%0.6f %0.6f\n", waterdepth, value(ssp))
     elseif ssp isa SampledFieldZ
-      @printf(io, "*\n%d 0\n*\n", length(ssp.zrange))
-      @printf(io, "%0.6f %0.6f 1 999\n", -z[1], ssp(z[1]))
+      @printf(io, "*(3)\n%d 0\n*(4)\n", length(ssp.zrange))
+      @printf(io, "%0.6f %0.6f 1 0\n", -z[1], ssp(z[1]))
       for z ∈ ssp.zrange[2:end]
         @printf(io, "%0.6f %0.6f\n", -z, ssp(z))
       end
     else
       n = _recommend_len(waterdepth, f)
-      @printf(io, "*\n%d 0\n*\n", n)
-      @printf(io, "%0.6f %0.6f 1 999\n", 0.0, ssp(0.0))
+      @printf(io, "*(3)\n%d 0\n*(4)\n", n)
+      @printf(io, "%0.6f %0.6f 1 0\n", 0.0, ssp(0.0))
       for d ∈ range(0.0, waterdepth; length=n)[2:end]
         @printf(io, "%0.6f %0.6f\n", -z, ssp(z))
       end
     end
-    println(io, "*\n0\n*")   # TODO: support bottom layers
-    @printf(io, "*\n%0.6f 0.0 %0.6f %0.6f 0.0 1.0 1.0\n", env.seabed.c, env.seabed.ρ / env.density, -in_dBperλ(env.seabed.δ))   # TODO: support elastic seabed
-    println(io, "*\n0\n*")
+    println(io, "*(5)\n0\n*(6)")   # TODO: support bottom layers
+    @printf(io, "*(7)\n%0.6f 0.0 %0.6f %0.6f 0.0\n", env.seabed.c, env.seabed.ρ / env.density, -in_dBperλ(env.seabed.δ))   # TODO: support elastic seabed
+    println(io, "*(8)\n0\n*(9)")
   end
   open(opt_filename, "w") do io
-    println(io, "*\n1.6 1 0 0 0 0 0")   # TODO: change last param to choose specific output format
-    @printf(io, "*\n%d %0.6f %0.6f %0.6f %0.6f %0.6f %0.6f %d 0 0\n",
+    println(io, "*(1)\n2.01 1 0 0 0 0 3")
+    @printf(io, "*(2)\n%d %0.6f %0.6f %0.6f %0.6f %0.6f %0.6f 0 0 0 0 0\n",
       pm.leaky ? 0 : 1, pm.min_phase_speed, pm.max_phase_speed, pm.rmin,
-      pm.rmax, pm.phase_step, pm.cutoff, pm.false_bottom ? 1 : 0)
+      pm.rmax, pm.phase_step, pm.cutoff)
     flist = [frequency(tx1) for tx1 ∈ tx]
     f = sum(flist) / length(flist)
     maximum(abs, flist .- f) / f > 0.2 && @warn("Source frequency varies by more than 20% from nominal frequency")
-    @printf(io, "*\n1 %0.6f\n", f)
-    @printf(io, "*\n1 %d 0 0 0 1 1 0 0 0 0\n", pm.mode_depths > 0 ? 1 : 0)
-    @printf(io, "*\n%d", length(tx))
+    @printf(io, "*(3)\n1 %0.6f\n", f)
+    @printf(io, "*(4)\n1 %d 0 0 0 1 1 0 0 0 0\n", pm.mode_depths > 0 ? 1 : 0)
+    @printf(io, "*(5)\n%d", length(tx))
     for tx1 ∈ tx
       @printf(io, " %0.6f", -location(tx1).z)
     end
@@ -83,10 +83,53 @@ function _create_orca(pm, tx, rx, dirname)
       error("Receivers must be on a 2D grid")
     end
     if pm.mode_depths > 0
-      @printf(io, "*\n3 0 %d 0 %0.6f\n", -pm.mode_depths, waterdepth)
+      @printf(io, "*(6)\n3 0 %d 0 %0.6f\n", -pm.mode_depths, waterdepth)
     else
-      println(io, "*")
+      println(io, "*(6)")
     end
-    println(io, "*\n*\n*\n*\n*\n*\n*\n*")
+    println(io, "*(7)\n*(8)\n*(9)\n*(10)\n*(11)\n*(12)\n*(13)\n*(14)")
+  end
+end
+
+### interface functions
+
+function UnderwaterAcoustics.arrivals(pm::Orca, tx1::AbstractAcousticSource, rx1::AbstractAcousticReceiver)
+  mktempdir(prefix="orca_") do dirname
+    _create_orca(pm, [tx1], [rx1], dirname)
+    _orca(dirname, pm.debug)
+    # TODO
+  end
+end
+
+function UnderwaterAcoustics.acoustic_field(pm::Orca, tx1::AbstractAcousticSource, rx::AcousticReceiverGrid2D)
+  fld = mktempdir(prefix="orca_") do dirname
+    _create_orca(pm, [tx1], rx, dirname)
+    _orca(dirname, pm.debug)
+    # TODO
+  end
+  # fld .* db2amp(spl(tx1))
+end
+
+function UnderwaterAcoustics.acoustic_field(pm::Orca, tx1::AbstractAcousticSource, rx1::AbstractAcousticReceiver)
+  fld = mktempdir(prefix="orca_") do dirname
+    _create_orca(pm, [tx1], [rx1], dirname)
+    _orca(dirname, pm.debug)
+    # TODO
+  end
+  # fld .* db2amp(spl(tx1))
+end
+
+### helper functions
+
+function _orca(dirname, debug)
+  outfilename = joinpath(dirname, "output.txt")
+  try
+    run(pipeline(Cmd(ORCA[]; ignorestatus=true, dir=dirname); stdout=outfilename, stderr=outfilename))
+    if debug
+      @info "Orca run completed in $dirname, press ENTER to delete intermediate files..."
+      readline()
+    end
+  catch
+    throw(ExecError("Orca", ["Unable to execute Orca"]))
   end
 end

--- a/src/orca.jl
+++ b/src/orca.jl
@@ -113,7 +113,7 @@ function _create_orca(pm, tx1, rx, dirname)
       @printf(io, "*(3)\n%d 0\n*(4)\n", n)
       @printf(io, "%0.6f %0.6f 1 %0.6f\n", 0.0, ssp(0.0), att)
       for d ∈ range(0.0, waterdepth; length=n)[2:end]
-        @printf(io, "%0.6f %0.6f\n", -z, ssp(z))
+        @printf(io, "%0.6f %0.6f\n", -d, ssp(d))
       end
     end
     if env.seabed isa MultilayerElasticBoundary
@@ -205,9 +205,9 @@ end
 function _check_env(::Type{Orca}, env)
   env.seabed isa FluidBoundary || env.seabed isa ElasticBoundary || env.seabed isa MultilayerElasticBoundary || error("seabed must be a FluidBoundary, ElasticBoundary or MultilayerElasticBoundary")
   env.surface isa FluidBoundary || error("surface must be a FluidBoundary")
-  is_range_dependent(env.soundspeed) && error("range-dependent soundspeed not supported")
-  is_range_dependent(env.altimetry) && error("range-dependent altimetry not supported")
-  is_range_dependent(env.bathymetry) && error("range-dependent bathymetry not supported")
+  is_range_dependent(env.soundspeed) && error("Range-dependent soundspeed not supported")
+  is_range_dependent(env.altimetry) && error("Range-dependent altimetry not supported")
+  is_range_dependent(env.bathymetry) && error("Range-dependent bathymetry not supported")
   mktempdir(prefix="orca_") do dirname
     try
       _orca(dirname, false)

--- a/src/orca.jl
+++ b/src/orca.jl
@@ -1,0 +1,92 @@
+export Orca
+
+const ORCA = Ref{Cmd}(`orca90.exe`) # (AcousticsToolbox_jll.orca90())
+
+"""
+A propagation model based on the ORCA model.
+"""
+Base.@kwdef struct Orca{T} <: AbstractRayPropagationModel
+  env::T
+  leaky::Bool = true
+  min_phase_speed::Float32 = 0.0
+  max_phase_speed::Float32 = 0.0
+  rmin::Float32 = 0.0
+  rmax::Float32 = 0.0
+  phase_step::Float32 = 1.0
+  cutoff::Float32 = 0.0
+  false_bottom::Bool = false
+  mode_depths::Int = 0
+end
+
+function _create_orca(pm, tx, rx, dirname)
+  name = basename(dirname)
+  svp_filename = joinpath(dirname, "orca.svp")
+  opt_filename = joinpath(dirname, "orca.opt")
+  out_filename = joinpath(dirname, "orca.out")
+  orca_filename = joinpath(dirname, "orca_in")
+  open(orca_filename, "w") do io
+    println(io, svp_filename)
+    println(io, opt_filename)
+    println(io, out_filename)
+  end
+  env = pm.env
+  waterdepth = maximum(env.bathymetry)
+  open(svp_filename, "w") do io
+    println(io, "*\n3.0 '$name'")
+    @printf(io, "*\n%0.6f 0.0 %0.6f %0.6f 0.0 1.0 1.0\n", env.surface.c, env.surface.ρ / env.density, -in_dBperλ(env.surface.δ))
+    ssp = env.soundspeed
+    if is_constant(ssp)
+      println(io, "*\n2 0\n*")
+      @printf(io, "0 %0.6f 1 999\n", value(ssp))
+      @printf(io, "%0.6f %0.6f\n", waterdepth, value(ssp))
+    elseif ssp isa SampledFieldZ
+      @printf(io, "*\n%d 0\n*\n", length(ssp.zrange))
+      @printf(io, "%0.6f %0.6f 1 999\n", -z[1], ssp(z[1]))
+      for z ∈ ssp.zrange[2:end]
+        @printf(io, "%0.6f %0.6f\n", -z, ssp(z))
+      end
+    else
+      n = _recommend_len(waterdepth, f)
+      @printf(io, "*\n%d 0\n*\n", n)
+      @printf(io, "%0.6f %0.6f 1 999\n", 0.0, ssp(0.0))
+      for d ∈ range(0.0, waterdepth; length=n)[2:end]
+        @printf(io, "%0.6f %0.6f\n", -z, ssp(z))
+      end
+    end
+    println(io, "*\n0\n*")   # TODO: support bottom layers
+    @printf(io, "*\n%0.6f 0.0 %0.6f %0.6f 0.0 1.0 1.0\n", env.seabed.c, env.seabed.ρ / env.density, -in_dBperλ(env.seabed.δ))   # TODO: support elastic seabed
+    println(io, "*\n0\n*")
+  end
+  open(opt_filename, "w") do io
+    println(io, "*\n1.6 1 0 0 0 0 0")   # TODO: change last param to choose specific output format
+    @printf(io, "*\n%d %0.6f %0.6f %0.6f %0.6f %0.6f %0.6f %d 0 0\n",
+      pm.leaky ? 0 : 1, pm.min_phase_speed, pm.max_phase_speed, pm.rmin,
+      pm.rmax, pm.phase_step, pm.cutoff, pm.false_bottom ? 1 : 0)
+    flist = [frequency(tx1) for tx1 ∈ tx]
+    f = sum(flist) / length(flist)
+    maximum(abs, flist .- f) / f > 0.2 && @warn("Source frequency varies by more than 20% from nominal frequency")
+    @printf(io, "*\n1 %0.6f\n", f)
+    @printf(io, "*\n1 %d 0 0 0 1 1 0 0 0 0\n", pm.mode_depths > 0 ? 1 : 0)
+    @printf(io, "*\n%d", length(tx))
+    for tx1 ∈ tx
+      @printf(io, " %0.6f", -location(tx1).z)
+    end
+    if length(rx) == 1
+      @printf(io, "\n1 %0.6f\n", -location(rx[1]).z)
+      @printf(io, "1 %0.6f\n", location(rx[1]).x / 1000)
+    elseif rx isa AcousticReceiverGrid2D
+      x = rx.xrange ./ 1000
+      z = -rx.zrange
+      @printf(io, "\n%d %0.6f %0.6f\n", -length(z), minimum(z), maximum(z))
+      @printf(io, "%d %0.6f %0.6f\n", -length(x), minimum(x), maximum(x))
+    else
+      error("Receivers must be on a 2D grid")
+    end
+    if pm.mode_depths > 0
+      @printf(io, "*\n3 0 %d 0 %0.6f\n", -pm.mode_depths, waterdepth)
+    else
+      println(io, "*")
+    end
+    println(io, "*\n*\n*\n*\n*\n*\n*\n*")
+  end
+end

--- a/test/test_orca.jl
+++ b/test/test_orca.jl
@@ -1,0 +1,26 @@
+using TestItems
+
+@testitem "orca-pekeris-modes" begin
+  using UnderwaterAcoustics
+  env = @inferred UnderwaterEnvironment(
+    bathymetry = 100,
+    soundspeed = 1500,
+    density = 1000,
+    seabed = FluidBoundary(2000, 2000)
+  )
+  tx = @inferred AcousticSource(0, -50, 300)
+  rx = @inferred AcousticReceiver(20000, -25)
+  for complex_solver ∈ [false, true]
+    pm = @inferred Orca(env; complex_solver)
+    m = @inferred arrivals(pm, tx, rx)
+    @test m isa Vector{<:UnderwaterAcoustics.ModeArrival}
+    pm1 = @inferred PekerisModeSolver(env)
+    m1 = @inferred arrivals(pm1, tx, rx)
+    @test [m[i].kᵣ for i ∈ 1:25] ≈ [m1[i].kᵣ for i ∈ 1:25] atol=0.001
+    @test [m[i].v for i ∈ 1:25] ≈ [m1[i].v for i ∈ 1:25] atol=0.1
+    rxs = AcousticReceiverGrid2D(20000:10:22000, -25)
+    x = @inferred transmission_loss(pm, tx, rxs)
+    x1 = @inferred transmission_loss(pm1, tx, rxs)
+    @test sum(abs, x1 - x) / length(x) < 1
+  end
+end


### PR DESCRIPTION
### Key changes

- Updates to `UnderwaterAcoustics.jl` `v0.6` API (changes to `interp` keyword argument for sampled fields)
- Adds support for ORCA normal mode model
- Minor code improvements to BELLHOP and KRAKEN
