### PR TITLE
Native Julia port of 2D BELLHOP as a new solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Manifest.toml
 /docs/build/
 .vscode
 TODO
+.testenv/

--- a/LICENSE-GPL-3.0
+++ b/LICENSE-GPL-3.0
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,19 @@
 name = "AcousticsToolbox"
 uuid = "268a15bc-5756-47d6-9bea-fa5dc21c97f8"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 AcousticsToolbox_jll = "6380ca6f-c335-511c-b45e-8a1ed8902ca7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
 AcousticsToolbox_jll = "2025.9.6"
+LinearAlgebra = "1"
 Printf = "1"
+StaticArrays = "1"
 UnderwaterAcoustics = "0.6,0.7,0.8"
 julia = "1.9"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Currently, the following models are supported:
 - Kraken 2D normal mode model
 - Orca 2D normal mode model
 - BellhopJL — a native Julia port of the 2D Bellhop Gaussian beam tracer
-  (no file I/O, ForwardDiff-differentiable)
+  (no file I/O, ForwardDiff-differentiable; see
+  [src/bellhopjl/PORTING_NOTES.md](src/bellhopjl/PORTING_NOTES.md) for the
+  port's provenance and deviations from the Fortran)
 
 For information on how to use the models, see [documentation](https://org-arl.github.io/UnderwaterAcoustics.jl/).
 
@@ -29,7 +31,9 @@ This package is dual-licensed on a per-directory basis:
   [A-New-BellHope](https://github.com/A-New-BellHope/bellhop) changes © 2021–2023
   The Regents of the University of California) — and is licensed under
   [GPL-3.0-or-later](LICENSE-GPL-3.0). Each file in that directory carries an
-  `SPDX-License-Identifier: GPL-3.0-or-later` header.
+  `SPDX-License-Identifier: GPL-3.0-or-later` header. The port's lineage and
+  every intentional deviation from the Fortran are documented in
+  [src/bellhopjl/PORTING_NOTES.md](src/bellhopjl/PORTING_NOTES.md).
 
 Note that this package already downloads and executes the GPL-licensed OALIB
 Fortran binaries (via `AcousticsToolbox_jll`) for the `Bellhop`/`Kraken` models, so

--- a/README.md
+++ b/README.md
@@ -14,8 +14,29 @@ Currently, the following models are supported:
 - Bellhop 2D Gaussian beam tracer
 - Kraken 2D normal mode model
 - Orca 2D normal mode model
+- BellhopJL — a native Julia port of the 2D Bellhop Gaussian beam tracer
+  (no file I/O, ForwardDiff-differentiable)
 
 For information on how to use the models, see [documentation](https://org-arl.github.io/UnderwaterAcoustics.jl/).
+
+## Licensing
+
+This package is dual-licensed on a per-directory basis:
+
+- Everything **except** `src/bellhopjl/` is licensed under the [MIT license](LICENSE).
+- `src/bellhopjl/` (the `BellhopJL` solver) is a native Julia port of Bellhop — a
+  derivative work of the GPL-licensed Bellhop (© 1983–2022 Michael B. Porter;
+  [A-New-BellHope](https://github.com/A-New-BellHope/bellhop) changes © 2021–2023
+  The Regents of the University of California) — and is licensed under
+  [GPL-3.0-or-later](LICENSE-GPL-3.0). Each file in that directory carries an
+  `SPDX-License-Identifier: GPL-3.0-or-later` header.
+
+Note that this package already downloads and executes the GPL-licensed OALIB
+Fortran binaries (via `AcousticsToolbox_jll`) for the `Bellhop`/`Kraken` models, so
+GPL software is involved either way; with the `BellhopJL` component included in the
+source tree, **distribution of the combined package is subject to the terms of the
+GPL-3.0**. If you need MIT-only terms, strip `src/bellhopjl/` (the rest of the
+package does not depend on it).
 
 ## Contributing
 
@@ -23,5 +44,6 @@ Contributions in the form of bug reports, feature requests, ideas/suggestions, b
 
 The scopes active in this repository are:
 - **bellhop**: Bellhop
+- **bellhopjl**: BellhopJL
 - **kraken**: Kraken
 - **orca**: Orca

--- a/src/AcousticsToolbox.jl
+++ b/src/AcousticsToolbox.jl
@@ -14,4 +14,11 @@ include("kraken.jl")
 include("orca.jl")
 include("common.jl")
 
+# BellhopJL (native Julia port of Bellhop) lives in an internal submodule;
+# note that unlike the rest of this package (MIT), src/bellhopjl/** is
+# GPL-3.0-or-later (see LICENSE-GPL-3.0)
+include("bellhopjl/BellhopJLCore.jl")
+using .BellhopJLCore: BellhopJL
+export BellhopJL
+
 end # module

--- a/src/bellhopjl/BellhopJLCore.jl
+++ b/src/bellhopjl/BellhopJLCore.jl
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# BellhopJLCore — native Julia port of the 2D Bellhop Gaussian-beam/ray tracer
+# (derivative work of Bellhop by Michael B. Porter, via the A-New-BellHope
+# bug-fixed mirror of Bellhop 2022_4). Unlike the rest of AcousticsToolbox.jl
+# (MIT), everything under src/bellhopjl/ is licensed GPL-3.0-or-later — see
+# LICENSE-GPL-3.0 at the repository root.
+#
+# This internal submodule keeps the port's helpers out of the parent
+# namespace; the public model type `BellhopJL` is re-exported by
+# AcousticsToolbox.
+
+module BellhopJLCore
+
+using LinearAlgebra
+using StaticArrays
+
+include("types.jl")
+include("ssp.jl")
+include("boundary.jl")
+include("attenuation.jl")
+include("reflection.jl")
+include("env.jl")
+include("step.jl")
+include("trace.jl")
+include("influence.jl")
+include("field.jl")
+include("api.jl")
+
+export BellhopJL
+
+end # module

--- a/src/bellhopjl/PORTING_NOTES.md
+++ b/src/bellhopjl/PORTING_NOTES.md
@@ -1,0 +1,129 @@
+# BellhopJL porting notes — provenance and deviations
+
+This directory contains a native Julia port of the 2D BELLHOP Gaussian beam /
+ray tracer. This file documents the port's lineage, every intentional deviation
+from the Fortran sources, and the provenance of the validation data.
+(Everything in `src/bellhopjl/` is GPL-3.0-or-later — see `LICENSE-GPL-3.0` at
+the repository root; the rest of AcousticsToolbox.jl is MIT.)
+
+## 1. Lineage
+
+Ported from **BELLHOP 2D as released in the OALIB Acoustics Toolbox 2022_4**,
+via the **A-New-BellHope mirror** (https://github.com/A-New-BellHope/bellhop,
+© 2021–2023 The Regents of the University of California; BELLHOP © 1983–2022
+Michael B. Porter), *including* its documented bug fixes. Docstrings and code
+comments cite the originating Fortran file/subroutine throughout (e.g. "ports
+`InfluenceGeoHatCart`, influence.f90") so the code remains diffable against
+upstream.
+
+The following **A-New-BellHope deviations from stock OALIB BELLHOP are
+deliberately retained** (stock OALIB, including the 2024_12_25 release, does
+not have them). They fix the reproducibility problem documented in the
+A-New-BellHope README — in stock BELLHOP the reduced integration step lands
+"randomly" just before or just after every boundary/interface crossing, so
+*every step of every ray is an edge case* whose resolution can differ between
+compilers, runs and implementations:
+
+- **Exact boundary landing (`StepToBdry2D`, Step.f90)** — the blended step is
+  placed *exactly* on the nearest SSP interface / boundary / box limit, with
+  snap-to-depth for flat boundaries, and reflections are signalled by explicit
+  `topRefl`/`botRefl` flags rather than a distance-sign test. Retained because
+  it makes results deterministic and well-defined; reverting it would
+  reintroduce the documented edge-case chaos.
+- **Tangent-direction-aware segment selection** (`GetTopSeg`/`GetBotSeg`,
+  bdryMod.f90; `UpdateDepthSegmentT`, sspMod.f90) — after landing exactly on a
+  node, the segment is chosen so that a small step along the ray stays inside
+  it. Required for the exact-landing scheme to be consistent.
+- **Small-step scheme** — `INFINITESIMAL_STEP_SIZE = 1e-6·deltas` (stock 2022
+  used a 1e-4 threshold with a 1e-5 makeup step; 2024 uses 1e-4/1e-4). The
+  smaller constant belongs with exact landing, which makes tiny cleanup steps
+  rare.
+- **Gaussian shallow-angle threshold 0.50001** (`InfluenceGeoGaussianCart`,
+  influence.f90) — moves a behavioural discontinuity off the round number so
+  rays launched at exactly 60° do not straddle it.
+
+## 2. Subsequently adopted OALIB 2024_12_25 corrections
+
+After the initial port, the 2D-relevant algorithmic changes of the official
+OALIB release 2024_12_25 (relative to the 2022_4 base) were reviewed and the
+following adopted:
+
+- **influence.f90 : `InfluenceGeoHatCart`, `InfluenceGeoGaussianCart`** — the
+  caustic phase shift at a receiver whose interpolated `q` straddles a caustic
+  is now *additive* (`phaseInt = phaseInt + π/2`); the 2022 code discarded the
+  accumulated ray phase (`phaseInt = phase + π/2`), a bug A-New-BellHope had
+  flagged but not fixed in 2D.
+- **influence.f90 : `InfluenceGeoGaussianCart`** — the ray phase is read from
+  the *previous* ray point (`ray2D(iS-1)%Phase`), consistent with the hat
+  influence; 2022 read the current point.
+- **Step.f90 : `Step2D`** — the SSP-interface jump correction on `p` is applied
+  only for SSP types with a discontinuous first derivative ('N'/'C'); C¹
+  profiles (spline 'S', PCHIP 'P', analytic 'A') get `gradcjump = 0`
+  (implemented as the `has_gradcjump` trait in `ssp.jl`).
+- **bellhopMod.f90** — `MaxN` (per-ray step cap) raised 100 000 → 1 000 000.
+
+Changes reviewed and **not** adopted: the 1e-4 small-step makeup constant (tied
+to the stock no-snapping stepping, see §1), receiver-position/env-file I/O
+precision changes (no file I/O here), Cerveny-beam changes (out of scope), and
+cosmetics. PCHIP (`misc/pchipMod.f90`), the spline coefficients
+(`misc/splinec.f90`), `Reflect2D` and the `AddArr` arrival merging are
+unchanged between 2022_4 and 2024_12_25.
+
+## 3. Other intentional deviations from the Fortran
+
+- **No env/ray/arr/shd file I/O** — environments come directly from
+  UnderwaterAcoustics.jl; the adapter (`api.jl`) mirrors the unit conversions
+  of this package's Fortran env-file writer verbatim (density ratio in g/cm³,
+  attenuation in dB/λ, Francois-Garrison volume attenuation with
+  z̄ = waterdepth/2, angle sign flips, 1.01× ray box, SSP node layout).
+- **Scope** — only the features reachable through the UnderwaterAcoustics.jl
+  API are implemented: geometric hat/Gaussian beams in Cartesian coordinates,
+  coherent/incoherent/semicoherent fields, arrivals/eigenrays. Cerveny and SGB
+  beams, ray-centered influences, 3D, and range-dependent SSPs ('Q'/'H') are
+  out of scope (the wrapper never selects them). Source beam patterns are not
+  implemented (the wrapper never writes SBP files).
+- **Semicoherent runs** are implemented via the Lloyd-mirror source amplitude
+  `√2·|sin(ω·zₛ·sin α/c)|` at launch (BellhopCore), matching the Fortran.
+- **PCHIP SSP not ported** — the wrapper maps interpolations only to
+  'C'/'S'/'Q', so 'P' is unreachable. C-linear, N²-linear and cubic-spline
+  (de Boor not-a-knot, `misc/splinec.f90` translated literally) are ported.
+- **Curvilinear ('C') boundary interpolation not implemented** — boundaries are
+  piecewise linear with the node-extension scheme of
+  `ComputeBdryTangentNormal`. The wrapper emits 'C' only for non-`Linear()`
+  `SampledFieldX` bathymetry; flagged for future work.
+- **Per-step receiver bracketing** — the monotone receiver-pointer walk of
+  `InfluenceGeoHatCart`/`InfluenceGeoGaussianCart` is ported faithfully; the
+  Fortran `MINLOC` start-index edge case (no receiver to the right of the
+  source ⇒ index 0, undefined behaviour) is guarded by clamping.
+- **Precision** — double precision throughout (the Fortran accumulates the TL
+  field in single-precision `COMPLEX*4` and quantizes .shd/.arr output).
+- **AD requirements** — all numeric structs are parametric so
+  `ForwardDiff.Dual`s flow through any single parameter class (SSP nodes,
+  bathymetry, seabed ρ/c/α, source/receiver coordinates, frequency);
+  `Env2D` permits heterogeneous element types across components; no `Float64`
+  hard-casts or `@fastmath` on dual-reachable paths.
+- The SSP interface jump is skipped for exactly horizontal rays (`t₂ = 0`
+  guard; the Fortran would divide by zero).
+- `AddArr` merges against the *last* arrival only, with `PhaseTol = 0.05` —
+  Fortran behaviour retained for parity (flagged as a bug by A-New-BellHope).
+
+## 4. Validation provenance
+
+- Analytic unit tests: straight rays and exact travel times (isovelocity),
+  circular-arc rays in a linear gradient, reflection phase/amplitude, Rayleigh
+  coefficient cross-checked against `UnderwaterAcoustics.reflection_coef`.
+- **Golden references** (hardcoded constants in `test/test_bellhopjl.jl`) were
+  generated with the Fortran BELLHOP shipped by **AcousticsToolbox_jll
+  v2025.9.6**, which is built from the official OALIB `at_2024_12_25.zip`
+  (SHA-pinned in Yggdrasil), driven through this package's `Bellhop` wrapper on
+  Pekeris (coherent + incoherent TL, arrivals) and Munk spline-SSP (Gaussian
+  beams, incoherent TL) scenarios. A direct in-process `BellhopJL`-vs-`Bellhop`
+  consistency test asserts median |ΔTL| < 0.1 dB on a Pekeris grid.
+- **Known residual**: on Munk-type spline SSPs the *coherent* TL of this port
+  differs from the OALIB binary by ~1–2 dB median (amplitude/incoherent
+  agreement is ~0.02 dB median). This is explained by the retained
+  A-New-BellHope stepping (§1): stock OALIB lands randomly before/after each
+  of the many SSP-interface crossings, accumulating O(1e-4–1e-3 s) delay
+  differences on multi-bounce paths — the same order as the OALIB binary's own
+  sensitivity to a ±1 change in beam count. Amplitude-level agreement is
+  therefore tested tightly and coherent spline-SSP agreement statistically.

--- a/src/bellhopjl/api.jl
+++ b/src/bellhopjl/api.jl
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# UnderwaterAcoustics.jl integration. This is the only file that touches
+# UnderwaterAcoustics.jl types; it mirrors the environment handling (and unit
+# conversions) of the Fortran Bellhop wrapper (src/bellhop.jl and
+# src/common.jl _write_env) so that BellhopJL is a drop-in alternative.
+
+using UnderwaterAcoustics
+using UnderwaterAcoustics: AbstractRayPropagationModel, AbstractAcousticSource,
+                           AbstractAcousticReceiver, AcousticReceiverGrid2D,
+                           RayArrival, SampledFieldX, SampledFieldZ,
+                           RigidBoundary, PressureReleaseBoundary, FluidBoundary,
+                           is_range_dependent, is_constant, value, in_units,
+                           db2amp, in_dBperλ, CubicSpline, Linear, XYZ
+
+"""
+    BellhopJL(env; kwargs...)
+
+Native-Julia port of the 2D Bellhop Gaussian-beam/ray tracer — a drop-in
+alternative to the Fortran-wrapping `Bellhop` model in this package,
+differentiable with ForwardDiff.
+
+Supported keyword arguments:
+- `nbeams`: number of beams to use (default: 0, auto)
+- `min_angle`: minimum beam angle (default: -80°)
+- `max_angle`: maximum beam angle (default: 80°)
+- `beam_type`: `:geometric` (default) or `:gaussian`
+"""
+struct BellhopJL{T} <: AbstractRayPropagationModel
+    env::T
+    nbeams::Int
+    min_angle::Float64      # [rad], UA convention (positive up)
+    max_angle::Float64
+    gaussian::Bool
+    function BellhopJL(env, nbeams, min_angle, max_angle, beam_type)
+        env.seabed isa FluidBoundary ||
+            error("seabed must be a FluidBoundary")
+        env.surface isa FluidBoundary ||
+            error("surface must be a FluidBoundary")
+        min_angle = in_units(u"rad", min_angle)
+        max_angle = in_units(u"rad", max_angle)
+        -π/2 ≤ min_angle ≤ π/2 || error("min_angle should be between -π/2 and π/2")
+        -π/2 ≤ max_angle ≤ π/2 || error("max_angle should be between -π/2 and π/2")
+        min_angle < max_angle || error("max_angle should be more than min_angle")
+        beam_type ∈ (:geometric, :gaussian) || error("Unknown beam_type type")
+        new{typeof(env)}(env, max(nbeams, 0), Float64(min_angle),
+                         Float64(max_angle), beam_type === :gaussian)
+    end
+end
+
+BellhopJL(env; nbeams=0, min_angle=-80°, max_angle=80°, beam_type=:geometric) =
+    BellhopJL(env, nbeams, min_angle, max_angle, beam_type)
+
+Base.show(io::IO, pm::BellhopJL) = print(io, "BellhopJL(⋯)")
+
+### adapter helpers
+
+function _check2d(tx, rxs)
+    location(tx).x == 0 || error("Transmitter must be at (0, 0, z)")
+    location(tx).y == 0 || error("2D model requires transmitter in the x-z plane")
+    all(location(rx).x >= 0 for rx in rxs) || error("Receivers must be in the +x halfspace")
+    all(location(rx).y == 0 for rx in rxs) || error("2D model requires receivers in the x-z plane")
+    nothing
+end
+
+# nominal half-wavelength sampling for range-dependent boundary functions
+# (mirrors _recommend_len in AcousticsToolbox.jl/src/common.jl)
+function _recommend_len(x, f)
+    λ = 1500.0 / f
+    clamp(round(Int, 2x / λ) + 1, 25, 1000)
+end
+
+# UA FluidBoundary → Bellhop halfspace BC. Unit conversions copied from the
+# wrapper's env writer: density ratio = ρ/1000 (g/cm³, water = 1), attenuation
+# in dB/λ via in_dBperλ(δ).
+function _make_bc(b::FluidBoundary, f)
+    if isinf(b.c) && isinf(b.ρ)
+        RigidBC()
+    elseif b.c == 0 && b.ρ == 0
+        VacuumBC()
+    else
+        HalfspaceBC(b.ρ / 1000, b.c, in_dBperλ(b.δ), f)
+    end
+end
+
+# UA soundspeed field → (depth nodes, complex speed nodes, spline?)
+# mirrors the SSP block of _write_env (common.jl)
+function _make_ssp_nodes(ssp, waterdepth, f, fg)
+    if is_constant(ssp)
+        c = value(ssp)
+        zn = [zero(waterdepth), waterdepth]
+        cn = [crci(c, zero(c), f; volume=fg) for _ in 1:2]
+        return zn, cn, false
+    elseif ssp isa SampledFieldZ
+        zrange = sort!(vcat(collect(ssp.zrange), -waterdepth); rev=true)
+        zn = eltype(zrange)[]
+        cn = []
+        for z in zrange
+            push!(zn, -z)
+            push!(cn, crci(ssp(z), zero(ssp(z)), f; volume=fg))
+            z == -waterdepth && break
+        end
+        return zn, [c for c in cn], ssp.interp === CubicSpline()
+    else
+        zn = collect(range(zero(waterdepth), waterdepth; length=_recommend_len(waterdepth, f)))
+        cn = [crci(ssp(-z), zero(ssp(-z)), f; volume=fg) for z in zn]
+        if !any(z -> z == waterdepth, zn)
+            push!(zn, waterdepth)
+            push!(cn, crci(ssp(-waterdepth), zero(ssp(-waterdepth)), f; volume=fg))
+        end
+        return zn, cn, false
+    end
+end
+
+# UA bathymetry/altimetry → Boundary2D (mirrors _create_alt_bathy_file sampling)
+function _make_boundary(data, func, maxr, f; top::Bool)
+    if !is_range_dependent(data)
+        return flat_boundary(func(data, (0.0, 0.0)); top)
+    end
+    x = data isa SampledFieldX ? collect(data.xrange) :
+        collect(range(0.0, maxr; length=_recommend_len(maxr, f)))
+    z = [func(data, (x1, 0.0)) for x1 in x]
+    Boundary2D(x, z; top)
+end
+
+"""
+Build the internal `Env2D` (+ source depth, beam parameters) from a UA
+environment, source and receiver extent.
+"""
+function _make_env2d(pm::BellhopJL, tx, maxr; nbeams=0)
+    env = pm.env
+    f = frequency(tx)
+    zs = -location(tx).z
+    bathy = env.bathymetry
+    waterdepth = maximum(bathy)
+    fg = FrancoisGarrison(float(env.temperature), float(env.salinity),
+                          float(env.pH), float(waterdepth / 2))
+
+    zn, cn, spline = _make_ssp_nodes(env.soundspeed, waterdepth, f, fg)
+    ssp = spline ? SplineSSP(zn, cn) : CLinearSSP(zn, cn)
+
+    top = _make_boundary(env.altimetry, (q, p) -> -value(q, p), maxr, f; top=true)
+    bot = _make_boundary(bathy, value, maxr, f; top=false)
+
+    topbc = _make_bc(env.surface, f)
+    botbc = _make_bc(env.seabed, f)
+
+    env2d = Env2D(float(f), ssp, top, bot, topbc, botbc)
+
+    # element type for beam parameters (must carry duals of bathymetry/range/freq)
+    T = promote_type(eltype(ssp), typeof(float(waterdepth)), typeof(float(maxr)),
+                     typeof(float(f)))
+    n = nbeams > 0 ? nbeams :
+        pm.nbeams > 0 ? pm.nbeams : auto_nbeams(f, maxr, waterdepth)
+    beam = BeamParams(deltas=T(waterdepth / 10), box_r=T(1.01 * maxr),
+                      box_z=T(1.01 * waterdepth), nbeams=n,
+                      αmin=T(-pm.max_angle), αmax=T(-pm.min_angle),
+                      gaussian=pm.gaussian)
+    env2d, zs, beam
+end
+
+_runmode(mode) = mode === :coherent ? COHERENT :
+                 mode === :incoherent ? INCOHERENT :
+                 mode === :semicoherent ? SEMICOHERENT :
+                 error("Unknown mode :" * string(mode))
+
+### interface functions
+
+function UnderwaterAcoustics.acoustic_field(pm::BellhopJL,
+        tx::AbstractAcousticSource, rxs::AcousticReceiverGrid2D; mode=:coherent)
+    _check2d(tx, rxs)
+    runmode = _runmode(mode)
+    xrev = first(rxs.xrange) > last(rxs.xrange)
+    rxr = xrev ? reverse(collect(rxs.xrange)) : collect(rxs.xrange)
+    rxz = [-z for z in rxs.zrange]
+    maxr = maximum(rxs.xrange)
+    env2d, zs, beam = _make_env2d(pm, tx, maxr)
+    U = pressure_field(env2d, zs, rxr, rxz, beam, runmode)   # (nz, nr)
+    fld = -permutedims(U) .* db2amp(spl(tx))                 # (nr, nz)
+    xrev ? reverse(fld; dims=1) : fld
+end
+
+function UnderwaterAcoustics.acoustic_field(pm::BellhopJL,
+        tx::AbstractAcousticSource, rx::AbstractAcousticReceiver; mode=:coherent)
+    _check2d(tx, (rx,))
+    runmode = _runmode(mode)
+    p = location(rx)
+    env2d, zs, beam = _make_env2d(pm, tx, p.x)
+    U = pressure_field(env2d, zs, [p.x], [-p.z], beam, runmode)
+    -U[1, 1] * db2amp(spl(tx))
+end
+
+function UnderwaterAcoustics.arrivals(pm::BellhopJL,
+        tx::AbstractAcousticSource, rx::AbstractAcousticReceiver; paths=true)
+    _check2d(tx, (rx,))
+    p = location(rx)
+    nbeams = pm.nbeams
+    nbeams == 0 &&
+        (nbeams = round(Int, (pm.max_angle - pm.min_angle) / deg2rad(0.05)) + 1)
+    env2d, zs, beam = _make_env2d(pm, tx, p.x; nbeams)
+    f = env2d.freq
+    arr = compute_arrivals(env2d, zs, [p.x], [-p.z], beam)[1, 1]
+    out = map(arr) do a
+        ϕ = a.amp * cis(a.phase) * exp(2π * f * imag(a.delay))
+        path = if paths
+            ray = trace_ray(env2d, a.src_angle, zs, beam)
+            [(x=pt.x[1], y=zero(pt.x[1]), z=-pt.x[2]) for pt in ray]
+        else
+            missing
+        end
+        RayArrival(real(a.delay), complex(ϕ), a.ntop, a.nbot,
+                   -a.src_angle, a.rcv_angle, path)
+    end
+    sort(out; by=a -> a.t)
+end

--- a/src/bellhopjl/attenuation.jl
+++ b/src/bellhopjl/attenuation.jl
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Attenuation conversions. Ports misc/AttenMod.f90 (CRCI, Franc_Garr).
+
+# dB → Nepers conversion constant used throughout Bellhop (20 log10 e)
+const DB_PER_NEPER = 8.6858896
+
+"""
+    crci(c, α_dbλ, freq; volume=nothing)
+
+Convert real sound speed + attenuation in dB/wavelength ('W' unit — the option
+the AcousticsToolbox wrapper writes) into a complex sound speed with positive
+imaginary part. Ports `CRCI` (misc/AttenMod.f90):
+
+    αT [Np/m] = α[dB/λ] · f / (8.6858896 · c)  (+ volume attenuation)
+    cimag     = αT · c² / ω
+    c̃         = c + i·cimag
+
+`volume` may be a `FrancoisGarrison` (wrapper option 'F') to add volume
+attenuation, or `:thorp` for Thorp.
+"""
+function crci(c, α_dbλ, freq; volume=nothing)
+    ω = 2π * freq
+    αT = iszero(c) ? zero(α_dbλ * freq / c) : α_dbλ * freq / (DB_PER_NEPER * c)
+    if volume === :thorp
+        αT += thorp(freq) / (DB_PER_NEPER * 1000)              # dB/km → Np/m
+    elseif volume isa FrancoisGarrison
+        αT += franc_garr(volume, freq / 1000) / (DB_PER_NEPER * 1000)
+    end
+    cimag = αT * c^2 / ω
+    complex(c, cimag)
+end
+
+"""
+    thorp(freq) -> α in dB/km
+
+Thorp volume attenuation, updated formula from JKPS Eq. 1.34 as in
+AttenMod.f90 ('T' option). `freq` in Hz.
+"""
+function thorp(freq)
+    f2 = (freq / 1000)^2
+    3.3e-3 + 0.11 * f2 / (1 + f2) + 44 * f2 / (4100 + f2) + 3.0e-4 * f2
+end
+
+"Francois-Garrison volume-attenuation parameters (misc/AttenMod.f90 module vars)."
+struct FrancoisGarrison{T<:Real}
+    temperature::T   # deg C
+    salinity::T      # psu
+    pH::T
+    z_bar::T         # depth [m]
+end
+
+FrancoisGarrison(t, s, pH, z̄) = FrancoisGarrison(promote(t, s, pH, z̄)...)
+
+"""
+    franc_garr(p, f) -> α in dB/km
+
+Francois-Garrison attenuation at frequency `f` [kHz]. Ports `Franc_Garr`
+(misc/AttenMod.f90).
+"""
+function franc_garr(p::FrancoisGarrison, f)
+    T, S, pH, z_bar = p.temperature, p.salinity, p.pH, p.z_bar
+    c = 1412 + 3.21 * T + 1.19 * S + 0.0167 * z_bar
+    # boric acid contribution
+    A1 = 8.86 / c * 10^(0.78 * pH - 5)
+    P1 = 1
+    f1 = 2.8 * sqrt(S / 35) * 10^(4 - 1245 / (T + 273))
+    # magnesium sulfate contribution
+    A2 = 21.44 * S / c * (1 + 0.025 * T)
+    P2 = 1 - 1.37e-4 * z_bar + 6.2e-9 * z_bar^2
+    f2 = 8.17 * 10^(8 - 1990 / (T + 273)) / (1 + 0.0018 * (S - 35))
+    # viscosity
+    P3 = 1 - 3.83e-5 * z_bar + 4.9e-10 * z_bar^2
+    A3 = T < 20 ?
+        4.937e-4 - 2.59e-5 * T + 9.11e-7 * T^2 - 1.5e-8 * T^3 :
+        3.964e-4 - 1.146e-5 * T + 1.45e-7 * T^2 - 6.5e-10 * T^3
+    A1 * P1 * (f1 * f^2) / (f1^2 + f^2) + A2 * P2 * (f2 * f^2) / (f2^2 + f^2) +
+        A3 * P3 * f^2
+end

--- a/src/bellhopjl/boundary.jl
+++ b/src/bellhopjl/boundary.jl
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Piecewise-linear altimetry/bathymetry. Ports bdryMod.f90
+# (ComputeBdryTangentNormal, GetTopSeg/GetBotSeg). Normals are OUTWARD
+# pointing (out of the water column), as in the Fortran:
+#   bottom: n = (-t₂, +t₁)  (flat bottom ⇒ (0, +1), pointing down/out)
+#   top:    n = (+t₂, -t₁)  (flat top    ⇒ (0, -1), pointing up/out)
+# Distances2D: Dist = -dot(n, x - bdry_x) is positive inside the water.
+
+struct Boundary2D{T<:Real}
+    rnode::Vector{T}          # node ranges (increasing, extended to ±BDRY_BIG)
+    x::Vector{SVector{2,T}}   # nodes (r, z)
+    t::Vector{SVector{2,T}}   # unit tangent per segment (length n-1)
+    n::Vector{SVector{2,T}}   # unit outward normal per segment
+    len::Vector{T}            # segment lengths
+    κ::Vector{T}              # curvature per segment (0 for piecewise linear)
+end
+
+"""
+    Boundary2D(r, z; top)
+
+Piecewise-linear boundary through nodes `(r[i], z[i])`, extended to ±∞ in a
+piecewise-constant fashion as in `ComputeBdryTangentNormal` (bdryMod.f90).
+"""
+function Boundary2D(r::AbstractVector, z::AbstractVector; top::Bool)
+    T = float(promote_type(eltype(r), eltype(z)))
+    m = length(r)
+    @assert length(z) == m ≥ 1
+    big = T(BDRY_BIG)
+    rv = vcat(-big, collect(T, r), big)
+    zv = vcat(T(z[1]), collect(T, z), T(z[end]))
+    n = length(rv)
+    pts = [SVector{2,T}(rv[i], zv[i]) for i in 1:n]
+    tv = Vector{SVector{2,T}}(undef, n - 1)
+    nv = Vector{SVector{2,T}}(undef, n - 1)
+    lv = Vector{T}(undef, n - 1)
+    for i in 1:n-1
+        d = pts[i+1] - pts[i]
+        l = norm(d)
+        d = d / l
+        tv[i] = d
+        lv[i] = l
+        nv[i] = top ? SVector(d[2], -d[1]) : SVector(-d[2], d[1])
+    end
+    Boundary2D{T}(rv, pts, tv, nv, lv, zeros(T, n - 1))
+end
+
+"Flat boundary at depth z0."
+flat_boundary(z0; top::Bool) = Boundary2D([zero(z0)], [z0]; top)
+
+"""
+    get_seg(b, r, tr) -> i
+
+Segment index for range `r` with the tangent-direction-aware edge handling of
+`GetTopSeg`/`GetBotSeg` (bdryMod.f90): with `tr > 0` the segment satisfies
+`rnode[i] <= r`, otherwise `rnode[i] < r`.
+"""
+@inline function get_seg(b::Boundary2D, r, tr)
+    n = length(b.rnode)
+    i = tr > 0 ? searchsortedlast(b.rnode, r) :
+                 searchsortedfirst(b.rnode, r) - 1   # last node with rnode < r
+    clamp(i, 1, n - 1)
+end
+
+"Geometry of segment i: anchor point, tangent, outward normal, r-interval, curvature."
+@inline function segment_geom(b::Boundary2D, i::Int)
+    (x = b.x[i], t = b.t[i], n = b.n[i], len = b.len[i],
+     rseg = (b.rnode[i], b.rnode[i+1]), κ = b.κ[i])
+end
+
+"""
+Signed perpendicular distances of x to top and bottom (positive = inside the
+water). Ports `Distances2D` (bellhop.f90) — outward normals, hence the minus.
+"""
+@inline function distances(x::SVector{2}, topg, botg)
+    dtop = -dot(topg.n, x - topg.x)
+    dbot = -dot(botg.n, x - botg.x)
+    dtop, dbot
+end

--- a/src/bellhopjl/env.jl
+++ b/src/bellhopjl/env.jl
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Internal, self-contained 2D environment in Bellhop-native conventions
+(z positive down, source at r = 0). Constructed by the API adapter (api.jl).
+
+The numeric element types of the components may differ (e.g. dual-number SSP
+nodes with plain-Float64 boundaries when differentiating w.r.t. soundspeed);
+`env_eltype` gives the promoted scalar type.
+"""
+struct Env2D{T1<:Real, S<:AbstractSSP, B1<:Boundary2D, B2<:Boundary2D,
+             TB<:BoundaryCondition, BB<:BoundaryCondition}
+    freq::T1
+    ssp::S
+    top::B1
+    bot::B2
+    topbc::TB
+    botbc::BB
+end
+
+Base.eltype(::Boundary2D{T}) where {T} = T
+bc_eltype(::BoundaryCondition) = Bool          # neutral in promote_type
+bc_eltype(::HalfspaceBC{T}) where {T} = T
+bc_eltype(::TabulatedBC{T}) where {T} = T
+
+env_eltype(env::Env2D) =
+    promote_type(typeof(float(env.freq)), eltype(env.ssp), eltype(env.top),
+                 eltype(env.bot), bc_eltype(env.topbc), bc_eltype(env.botbc),
+                 Float64)
+
+"Evaluate the SSP at position x = (r, z) with scaled tangent t. Returns (SSPEval, iseg)."
+@inline evalssp(env::Env2D, x::SVector{2}, t::SVector{2}, iseg::Int) =
+    evaluate(env.ssp, x[2], t[2], iseg)

--- a/src/bellhopjl/field.jl
+++ b/src/bellhopjl/field.jl
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Beam loop, pressure assembly and arrivals. Ports the beam loop of
+# BellhopCore and ScalePressure (influence.f90).
+
+"Uniform fan of take-off angles (BellhopCore / ReadRayElevationAngles)."
+function takeoff_angles(::Type{T}, beam::BeamParams) where {T}
+    n = beam.nbeams
+    n == 1 && return [T((beam.αmin + beam.αmax) / 2)], one(T)
+    Δα = (T(beam.αmax) - T(beam.αmin)) / (n - 1)
+    [T(beam.αmin) + (i - 1) * Δα for i in 1:n], Δα
+end
+
+"""
+Automatic beam count for TL runs. Ports the Nalpha auto-selection of
+`ReadRayElevationAngles` (angleMod.f90): phase-based limit with c0 = 1500 and
+a beam-thinness limit w.r.t. water depth.
+"""
+function auto_nbeams(freq, rmax, depth)
+    n = max(floor(Int, 0.3 * rmax * freq / 1500), 300)
+    max(floor(Int, π / atan(depth / (10 * rmax))), n)
+end
+
+"Semi-coherent source amplitude (Lloyd mirror), BellhopCore ('S' runs)."
+semicoherent_amp0(ω, c, zs, α) = sqrt(2) * abs(sin(ω / c * zs * sin(α)))
+
+"""
+    pressure_field(env, zs, rxr, rxz, beam, mode) -> Matrix{Complex} (nz × nr)
+
+Trace all beams and assemble the receiver-grid pressure, including the final
+`ScalePressure` step. `rxr` ascending ranges [m], `rxz` depths [m, +down].
+"""
+function pressure_field(env::Env2D, zs, rxr, rxz, beam::BeamParams{TB},
+                        mode::RunMode) where {TB}
+    T = promote_type(env_eltype(env), typeof(float(zs)), TB)
+    ω = 2π * env.freq
+    αs, Δα = takeoff_angles(T, beam)
+    sink = PressureSink{T}(zeros(Complex{T}, length(rxz), length(rxr)), mode)
+    e0, _ = evaluate(env.ssp, T(zs), one(T), 1)
+    for α in αs
+        amp0 = mode == SEMICOHERENT ? semicoherent_amp0(ω, e0.c, T(zs), α) : one(T)
+        ray = trace_ray(env, α, zs, beam; amp0)
+        influence_geo_cart!(sink, ray, α, Δα, ω, env.freq, rxr, rxz;
+                            gaussian=beam.gaussian)
+    end
+    scale_pressure!(sink.U, mode, rxr)
+end
+
+"""
+Final scaling of the pressure field. Ports `ScalePressure` (influence.f90) for
+geometric beams (const = −1) and a point source: incoherent runs convert
+intensity to pressure, then each column is scaled by −1/√r (0 at r = 0).
+"""
+function scale_pressure!(U::Matrix{Complex{T}}, mode::RunMode, rxr) where {T}
+    if mode != COHERENT
+        @. U = sqrt(complex(abs(real(U))))    # intensity → pressure
+    end
+    for (ir, r) in pairs(rxr)
+        factor = iszero(r) ? zero(T) : -one(T) / sqrt(abs(T(r)))
+        @views U[:, ir] .*= factor
+    end
+    U
+end
+
+"""
+    compute_arrivals(env, zs, rxr, rxz, beam) -> Matrix{Vector{Arrival}}
+
+Arrivals at each receiver. Cylindrical-spreading factor 1/√r is applied to
+amplitudes, as in `WriteArrivalsASCII` (ArrMod.f90).
+"""
+function compute_arrivals(env::Env2D, zs, rxr, rxz,
+                          beam::BeamParams{TB}) where {TB}
+    T = promote_type(env_eltype(env), typeof(float(zs)), TB)
+    ω = 2π * env.freq
+    αs, Δα = takeoff_angles(T, beam)
+    arr = [Arrival{T}[] for _ in eachindex(rxz), _ in eachindex(rxr)]
+    sink = ArrivalSink{T}(arr)
+    for α in αs
+        ray = trace_ray(env, α, zs, beam)
+        influence_geo_cart!(sink, ray, α, Δα, ω, env.freq, rxr, rxz;
+                            gaussian=beam.gaussian)
+    end
+    for ir in eachindex(rxr), iz in eachindex(rxz)
+        r = rxr[ir]
+        factor = iszero(r) ? T(1e5) : 1 / sqrt(abs(T(r)))
+        v = arr[iz, ir]
+        for (k, a) in pairs(v)
+            v[k] = Arrival{T}(factor * a.amp, a.phase, a.delay, a.src_angle,
+                              a.rcv_angle, a.ntop, a.nbot)
+        end
+    end
+    arr
+end

--- a/src/bellhopjl/influence.jl
+++ b/src/bellhopjl/influence.jl
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Geometric beam influence in Cartesian coordinates. Ports InfluenceGeoHatCart,
+# InfluenceGeoGaussianCart, ApplyContribution, IncPhaseIfCaustic, IsAtCaustic
+# and FinalPhase (influence.f90), and AddArr (ArrMod.f90).
+
+"AD-safe equivalent of Fortran SPACING for the duplicate-point tests."
+@inline _spacing(x) = 2.220446049250313e-16 * max(abs(x), one(x))
+
+# IsAtCaustic with qleq0 = .TRUE. (the variant used by all geometric beams)
+@inline _is_at_caustic(q, qold) =
+    (q <= 0 && qold > 0) || (q >= 0 && qold < 0)
+
+########################### sinks ###########################
+
+abstract type InfluenceSink end
+
+"Accumulates complex pressure (coherent) or intensity (in-/semicoherent)."
+struct PressureSink{T<:Real} <: InfluenceSink
+    U::Matrix{Complex{T}}     # (nz, nr)
+    mode::RunMode
+end
+
+"One discrete arrival. Amplitude/phase/delay as stored by `AddArr` (ArrMod.f90)."
+struct Arrival{T<:Real}
+    amp::T
+    phase::T
+    delay::Complex{T}
+    src_angle::T      # take-off angle [rad, positive down]
+    rcv_angle::T      # receiver angle [rad, positive down]
+    ntop::Int
+    nbot::Int
+end
+
+"Accumulates discrete arrivals per receiver."
+struct ArrivalSink{T<:Real} <: InfluenceSink
+    arr::Matrix{Vector{Arrival{T}}}     # (nz, nr)
+end
+
+"""
+Add an arrival, merging with the previous arrival at this receiver when both
+delay and phase agree within `PhaseTol = 0.05` (ports `AddArr`, ArrMod.f90;
+the amplitude-weighted merge keeps the previous phase, as the Fortran does).
+"""
+function add_arr!(v::Vector{Arrival{T}}, ω, amp, phase, delay, srcang, rcvang,
+                  ntop, nbot) where {T}
+    PhaseTol = T(0.05)
+    if !isempty(v)
+        b = v[end]
+        if ω * abs(delay - b.delay) < PhaseTol && abs(b.phase - phase) < PhaseTol
+            amptot = b.amp + amp
+            w1 = b.amp / amptot
+            w2 = amp / amptot
+            v[end] = Arrival{T}(amptot, b.phase, w1 * b.delay + w2 * delay,
+                                w1 * b.src_angle + w2 * srcang,
+                                w1 * b.rcv_angle + w2 * rcvang, b.ntop, b.nbot)
+            return v
+        end
+    end
+    push!(v, Arrival{T}(amp, phase, delay, srcang, rcvang, ntop, nbot))
+    v
+end
+
+# ApplyContribution (influence.f90)
+@inline function apply_contribution!(sink::PressureSink{T}, iz, ir, amp, w,
+                                     cnst, phaseInt, delay, ω, gaussian,
+                                     srcang, rcvang, ntop, nbot) where {T}
+    if sink.mode == COHERENT
+        sink.U[iz, ir] += amp * exp(-im * (ω * delay - phaseInt))
+    else  # incoherent / semicoherent: accumulate intensity
+        s = (cnst * exp(imag(ω * delay)))^2 * w
+        gaussian && (s *= sqrt(2 * T(π)))
+        sink.U[iz, ir] += s
+    end
+    nothing
+end
+
+@inline function apply_contribution!(sink::ArrivalSink{T}, iz, ir, amp, w,
+                                     cnst, phaseInt, delay, ω, gaussian,
+                                     srcang, rcvang, ntop, nbot) where {T}
+    add_arr!(sink.arr[iz, ir], ω, amp, phaseInt, delay, srcang, rcvang, ntop, nbot)
+    nothing
+end
+
+########################### influence ###########################
+
+"""
+    influence_geo_cart!(sink, ray, α, Δα, ω, freq, rxr, rxz; gaussian=false)
+
+Contribution of one beam to all receivers on the rectilinear grid
+`rxr × rxz` (ranges ascending). Ports `InfluenceGeoHatCart` (`gaussian=false`)
+and `InfluenceGeoGaussianCart` (`gaussian=true`) from influence.f90, including
+the monotone receiver-pointer walk, the KMAH caustic phase tracking, and the
+A-New-BellHope shallow-angle threshold change (0.50001) for Gaussian beams.
+"""
+function influence_geo_cart!(sink::InfluenceSink, ray::Vector{RayPt{T}}, α, Δα,
+                             ω, freq, rxr::AbstractVector,
+                             rxz::AbstractVector;
+                             gaussian::Bool=false) where {T}
+    nsteps = length(ray)
+    nsteps < 2 && return nothing
+    nrr = length(rxr)
+    hugeT = T(Inf)
+
+    q0 = ray[1].c / Δα                  # reference for J = q0 / q
+    phase = zero(T)
+    qOld = ray[1].q[1]
+    rA = ray[1].x[1]
+
+    # index of first receiver to the right of rA
+    ir = searchsortedlast(rxr, rA) + 1
+    ir > nrr && (ir = nrr)              # (Fortran MINLOC edge case; guarded)
+    ray[1].t[1] < 0 && ir > 1 && (ir -= 1)   # left-travelling ray
+
+    # sqrt(2π) represents a sum of Gaussians in free space; point source
+    ratio1 = sqrt(abs(cos(α)))
+    gaussian && (ratio1 /= sqrt(2 * T(π)))
+
+    BeamWindow = 4      # Gaussian beam window: kills beams outside e^(-0.5 w²)
+    srcang = T(α)
+
+    for is in 2:nsteps
+        rB = ray[is].x[1]
+        x_ray = ray[is-1].x
+
+        rayt = ray[is].x - x_ray
+        rlen = norm(rayt)
+        rlen < 1.0e3 * _spacing(ray[is].x[1]) && continue   # duplicate point
+        rayt = rayt / rlen
+        rayn = SVector(-rayt[2], rayt[1])
+        rcvang = atan(rayt[2], rayt[1])
+
+        dqds = ray[is].q[1] - ray[is-1].q[1]
+        dtauds = ray[is].τ - ray[is-1].τ
+
+        qseg = ray[is-1].q[1]
+        _is_at_caustic(qseg, qOld) && (phase += T(π) / 2)
+        qOld = qseg
+
+        λ = ray[is-1].c / freq
+        if gaussian
+            sigma = max(abs(ray[is-1].q[1]), abs(ray[is].q[1])) / q0 / abs(rayt[1])
+            sigma = max(sigma, min(T(0.2) * freq * real(ray[is].τ), T(π) * λ))
+            radiusMax = BeamWindow * sigma
+            shallow = abs(rayt[1]) > T(0.50001)
+        else
+            radiusMax = max(abs(ray[is-1].q[1]), abs(ray[is].q[1])) / q0 / abs(rayt[1])
+            shallow = abs(rayt[1]) > T(0.5)
+        end
+
+        # depth limits of beam
+        if shallow
+            zmin = min(ray[is-1].x[2], ray[is].x[2]) - radiusMax
+            zmax = max(ray[is-1].x[2], ray[is].x[2]) + radiusMax
+        else
+            zmin = -hugeT
+            zmax = +hugeT
+        end
+
+        while true
+            # is Rr(ir) contained in [rA, rB)? then compute beam influence
+            if min(rA, rB) <= rxr[ir] < max(rA, rB)
+                for iz in eachindex(rxz)
+                    x_rcvr = SVector(T(rxr[ir]), T(rxz[iz]))
+                    (zmin <= x_rcvr[2] <= zmax) || continue
+
+                    s = dot(x_rcvr - x_ray, rayt) / rlen  # proportional distance along ray
+                    n = abs(dot(x_rcvr - x_ray, rayn))    # normal distance to ray
+                    q = ray[is-1].q[1] + s * dqds         # interpolated amplitude
+
+                    if gaussian
+                        sigma = abs(q / q0)
+                        sigma = max(sigma,
+                                    min(T(0.2) * freq * real(ray[is].τ), T(π) * λ))
+                        if n < BeamWindow * sigma
+                            A = abs(q0 / q)
+                            delay = ray[is-1].τ + s * dtauds
+                            cnst = ratio1 * sqrt(ray[is].c / abs(q)) * ray[is].amp
+                            w = exp(-(n / sigma)^2 / 2) / (sigma * A)
+                            amp = cnst * w
+                            # FinalPhase (Gaussian reads phase from current point)
+                            phaseInt = _is_at_caustic(q, qOld) ?
+                                phase + T(π) / 2 : ray[is].phase + phase
+                            apply_contribution!(sink, iz, ir, amp, w, cnst,
+                                                phaseInt, delay, ω, true,
+                                                srcang, rcvang,
+                                                ray[is].ntop, ray[is].nbot)
+                        end
+                    else
+                        radius = abs(q / q0)              # beam radius
+                        if n < radius
+                            delay = ray[is-1].τ + s * dtauds
+                            cnst = ratio1 * sqrt(ray[is].c / abs(q)) * ray[is].amp
+                            w = (radius - n) / radius     # hat function
+                            amp = cnst * w
+                            # FinalPhase (hat reads phase from previous point)
+                            phaseInt = _is_at_caustic(q, qOld) ?
+                                phase + T(π) / 2 : ray[is-1].phase + phase
+                            apply_contribution!(sink, iz, ir, amp, w, cnst,
+                                                phaseInt, delay, ω, false,
+                                                srcang, rcvang,
+                                                ray[is].ntop, ray[is].nbot)
+                        end
+                    end
+                end
+            end
+
+            # bump receiver index towards rB
+            if rxr[ir] < rB
+                ir >= nrr && break
+                rxr[ir + 1] >= rB && break
+                ir += 1
+            else
+                ir <= 1 && break
+                rxr[ir - 1] <= rB && break
+                ir -= 1
+            end
+        end
+        rA = rB
+    end
+    nothing
+end

--- a/src/bellhopjl/influence.jl
+++ b/src/bellhopjl/influence.jl
@@ -178,9 +178,12 @@ function influence_geo_cart!(sink::InfluenceSink, ray::Vector{RayPt{T}}, α, Δ�
                             cnst = ratio1 * sqrt(ray[is].c / abs(q)) * ray[is].amp
                             w = exp(-(n / sigma)^2 / 2) / (sigma * A)
                             amp = cnst * w
-                            # FinalPhase (Gaussian reads phase from current point)
-                            phaseInt = _is_at_caustic(q, qOld) ?
-                                phase + T(π) / 2 : ray[is].phase + phase
+                            # OALIB 2024 InfluenceGeoGaussianCart (influence.f90):
+                            # ray phase read from the previous point (consistent
+                            # with hat) and the caustic π/2 is additive (the 2022
+                            # code discarded the accumulated phase)
+                            phaseInt = ray[is-1].phase + phase
+                            _is_at_caustic(q, qOld) && (phaseInt += T(π) / 2)
                             apply_contribution!(sink, iz, ir, amp, w, cnst,
                                                 phaseInt, delay, ω, true,
                                                 srcang, rcvang,
@@ -193,9 +196,11 @@ function influence_geo_cart!(sink::InfluenceSink, ray::Vector{RayPt{T}}, α, Δ�
                             cnst = ratio1 * sqrt(ray[is].c / abs(q)) * ray[is].amp
                             w = (radius - n) / radius     # hat function
                             amp = cnst * w
-                            # FinalPhase (hat reads phase from previous point)
-                            phaseInt = _is_at_caustic(q, qOld) ?
-                                phase + T(π) / 2 : ray[is-1].phase + phase
+                            # OALIB 2024 InfluenceGeoHatCart (influence.f90):
+                            # caustic π/2 is additive, no longer discarding the
+                            # accumulated ray phase
+                            phaseInt = ray[is-1].phase + phase
+                            _is_at_caustic(q, qOld) && (phaseInt += T(π) / 2)
                             apply_contribution!(sink, iz, ir, amp, w, cnst,
                                                 phaseInt, delay, ω, false,
                                                 srcang, rcvang,

--- a/src/bellhopjl/reflection.jl
+++ b/src/bellhopjl/reflection.jl
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Boundary conditions and reflection coefficients. Ports the boundary-condition
+# branch of Reflect2D (bellhop.f90) and InterpolateReflectionCoefficient
+# (misc/RefCoef.f90).
+
+abstract type BoundaryCondition end
+
+struct VacuumBC <: BoundaryCondition end                            # 'V'
+struct RigidBC  <: BoundaryCondition end                            # 'R'
+
+"Fluid halfspace ('A'). `ρ` is the density *ratio* (g/cm³ with water = 1)."
+struct HalfspaceBC{T<:Real} <: BoundaryCondition
+    ρ::T           # density ratio (halfspace ρ / water ρ)
+    cp::Complex{T} # complex compressional speed (CRCI of c, α[dB/λ])
+end
+
+function HalfspaceBC(ρ, c, α_dbλ, freq)
+    cp = crci(c, α_dbλ, freq)
+    T = promote_type(typeof(float(ρ)), typeof(real(cp)))
+    HalfspaceBC{T}(T(ρ), Complex{T}(cp))
+end
+
+"Tabulated reflection coefficient ('F'): grazing angle [deg], |R|, phase [rad]."
+struct TabulatedBC{T<:Real} <: BoundaryCondition
+    θ::Vector{T}
+    R::Vector{T}
+    φ::Vector{T}
+end
+
+"""
+    reflection_coefficient(bc, Tg, Th, ω) -> (amp_scale, phase_add)
+
+Reflection amplitude/phase updates for a boundary, given the tangential (`Tg`)
+and normal (`Th`) components of the *scaled* incident tangent along the
+boundary tangent/outward normal. Ports the `SELECT CASE ( HS%BC )` block of
+`Reflect2D` (bellhop.f90). Returns the multiplicative amplitude factor and
+additive phase.
+"""
+reflection_coefficient(::RigidBC, Tg, Th, ω) = (one(Tg), zero(Tg))
+reflection_coefficient(::VacuumBC, Tg, Th, ω) = (one(Tg), oftype(Tg, π))
+
+function reflection_coefficient(bc::HalfspaceBC, Tg, Th, ω)
+    kx = ω * Tg           # wavenumber along boundary
+    kz = ω * Th           # wavenumber perpendicular to boundary (in ocean)
+    # fluid bottom branch (HS%cS = 0): kzP = sqrt(kx² − (ω/cP)²)
+    kzP = sqrt(complex(kx^2) - (ω / bc.cp)^2)
+    # Intel/GFortran differ on the branch of sqrt for negative reals:
+    if real(kzP) == 0 && imag(kzP) < 0
+        kzP = -kzP
+    end
+    f = kzP
+    g = bc.ρ
+    ρw = one(real(f))     # water density is 1 in Bellhop's units
+    R = -(ρw * f - im * kz * g) / (ρw * f + im * kz * g)
+    aR = abs(R)
+    if aR < 1.0e-5        # kill a ray that has lost its energy in reflection
+        (zero(aR), zero(aR))
+    else
+        (aR, atan(imag(R), real(R)))
+    end
+end
+
+function reflection_coefficient(bc::TabulatedBC, Tg, Th, ω)
+    # angle of incidence relative to normal; symmetric about 90°
+    θ = abs(atand(Th, Tg))
+    θ > 90 && (θ = 180 - θ)
+    # InterpolateReflectionCoefficient (misc/RefCoef.f90): linear interpolation,
+    # R = 0 outside the tabulated domain
+    n = length(bc.θ)
+    i = clamp(searchsortedlast(bc.θ, θ), 1, n - 1)
+    if θ < bc.θ[1] || θ > bc.θ[n]
+        return (zero(θ), zero(θ))
+    end
+    w = (θ - bc.θ[i]) / (bc.θ[i+1] - bc.θ[i])
+    Rm = bc.R[i] + w * (bc.R[i+1] - bc.R[i])
+    φ = bc.φ[i] + w * (bc.φ[i+1] - bc.φ[i])
+    (Rm, φ)
+end

--- a/src/bellhopjl/ssp.jl
+++ b/src/bellhopjl/ssp.jl
@@ -20,6 +20,14 @@ abstract type AbstractSSP{T<:Real} end
 Base.eltype(::AbstractSSP{T}) where {T} = T
 
 """
+True if the SSP has a discontinuous first derivative at layer interfaces, so
+the ray-tracing p-jump correction applies. OALIB 2024 Step2D (Step.f90) gates
+the interface jump on SSP type: 'N'/'C' (and 'Q'/'H') yes; 'S'/'P'/'A' (C¹
+profiles) no.
+"""
+has_gradcjump(::AbstractSSP) = true
+
+"""
     update_seg(z, zq, tz, iseg) -> iseg′
 
 Depth-segment update with the tangent-direction-aware edge-case handling of
@@ -198,3 +206,6 @@ end
     fxx = s.coef[3, i] + h * s.coef[4, i]
     SSPEval(real(f), imag(f), real(fx), real(fxx)), i
 end
+
+# C¹ SSPs get no interface jump (OALIB 2024 Step2D, Step.f90)
+has_gradcjump(::SplineSSP) = false

--- a/src/bellhopjl/ssp.jl
+++ b/src/bellhopjl/ssp.jl
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Sound-speed profiles + derivatives. Ports the depth-dependent interpolants of
+# sspMod.f90 (cLinear, n2Linear, cCubic, UpdateDepthSegmentT) and the de Boor
+# spline coefficients from misc/splinec.f90 (CSPLINE, end conditions
+# iBCBeg = iBCEnd = 0, i.e. not-a-knot).
+
+"Result of an SSP evaluation (range-independent SSPs ⇒ cr = crr = crz = 0)."
+struct SSPEval{T<:Real}
+    c::T
+    cimag::T
+    cz::T
+    czz::T
+end
+
+SSPEval(c, cimag, cz, czz) = SSPEval(promote(c, cimag, cz, czz)...)
+
+abstract type AbstractSSP{T<:Real} end
+
+Base.eltype(::AbstractSSP{T}) where {T} = T
+
+"""
+    update_seg(z, zq, tz, iseg) -> iseg′
+
+Depth-segment update with the tangent-direction-aware edge-case handling of
+`UpdateDepthSegmentT` (sspMod.f90): if the ray takes a small step in direction
+`tz` it remains in the same segment.
+"""
+@inline function update_seg(z::AbstractVector, zq, tz, iseg::Int)
+    n = length(z)
+    if tz >= 0
+        while zq < z[iseg] && iseg > 1
+            iseg -= 1
+        end
+        while zq >= z[iseg + 1] && iseg < n - 1
+            iseg += 1
+        end
+    else
+        while zq > z[iseg + 1] && iseg < n - 1
+            iseg += 1
+        end
+        while zq <= z[iseg] && iseg > 1
+            iseg -= 1
+        end
+    end
+    iseg
+end
+
+########################### C-linear ('C') ###########################
+
+"C-linear SSP. Ports `cLinear` (sspMod.f90); node speeds are complex (CRCI)."
+struct CLinearSSP{T<:Real} <: AbstractSSP{T}
+    z::Vector{T}
+    c::Vector{Complex{T}}
+    cz::Vector{Complex{T}}       # per-segment gradient
+end
+
+function CLinearSSP(z::AbstractVector, c::AbstractVector)
+    T = float(promote_type(eltype(z), real(eltype(c))))
+    zv = collect(T, z)
+    cv = collect(Complex{T}, c)
+    issorted(zv) || throw(ArgumentError("SSP depths must be increasing"))
+    length(zv) ≥ 2 || throw(ArgumentError("SSP needs at least 2 points"))
+    CLinearSSP{T}(zv, cv, diff(cv) ./ diff(zv))
+end
+
+@inline function evaluate(s::CLinearSSP{T}, zq, tz, iseg::Int) where {T}
+    i = update_seg(s.z, zq, tz, iseg)
+    cc = s.c[i] + (zq - s.z[i]) * s.cz[i]
+    SSPEval(real(cc), imag(cc), real(s.cz[i]), zero(real(cc))), i
+end
+
+########################### N²-linear ('N') ###########################
+
+"N²-linear SSP. Ports `n2Linear` (sspMod.f90)."
+struct N2LinearSSP{T<:Real} <: AbstractSSP{T}
+    z::Vector{T}
+    n2::Vector{Complex{T}}
+    n2z::Vector{Complex{T}}
+end
+
+function N2LinearSSP(z::AbstractVector, c::AbstractVector)
+    T = float(promote_type(eltype(z), real(eltype(c))))
+    zv = collect(T, z)
+    cv = collect(Complex{T}, c)
+    issorted(zv) || throw(ArgumentError("SSP depths must be increasing"))
+    n2 = 1 ./ cv .^ 2
+    N2LinearSSP{T}(zv, n2, diff(n2) ./ diff(zv))
+end
+
+@inline function evaluate(s::N2LinearSSP{T}, zq, tz, iseg::Int) where {T}
+    i = update_seg(s.z, zq, tz, iseg)
+    w = (zq - s.z[i]) / (s.z[i+1] - s.z[i])
+    cc = 1 / sqrt((1 - w) * s.n2[i] + w * s.n2[i+1])
+    c = real(cc)
+    cz = -c^3 * real(s.n2z[i]) / 2
+    czz = 3 * cz * cz / c
+    SSPEval(c, imag(cc), cz, czz), i
+end
+
+########################### Cubic spline ('S') ###########################
+
+"""
+Cubic-spline SSP. Ports `cCubic` (sspMod.f90) with de Boor `CSPLINE`
+coefficients (misc/splinec.f90), end conditions iBCBeg = iBCEnd = 0
+(not-a-knot). In segment i: f(h) = C1 + h(C2 + h(C3/2 + h C4/6)),
+h = z - z[i].
+"""
+struct SplineSSP{T<:Real} <: AbstractSSP{T}
+    z::Vector{T}
+    coef::Matrix{Complex{T}}      # 4 × n
+end
+
+"""
+    cspline_coefs(z, y) -> 4×n matrix
+
+Ports CSPLINE (misc/splinec.f90) for the iBCBeg = iBCEnd = 0 (not-a-knot)
+case actually used by Bellhop (`cCubic`, sspMod.f90). Direct translation.
+"""
+function cspline_coefs(tau::Vector{T}, y::Vector{Complex{T}}) where {T}
+    n = length(tau)
+    C = zeros(Complex{T}, 4, n)
+    C[1, :] .= y
+    L = n - 1
+    for m in 2:n
+        C[3, m] = tau[m] - tau[m-1]
+        C[4, m] = (C[1, m] - C[1, m-1]) / C[3, m]
+    end
+    # beginning boundary condition (IBCBEG = 0)
+    if n > 2
+        C[4, 1] = C[3, 3]
+        C[3, 1] = C[3, 2] + C[3, 3]
+        C[2, 1] = ((C[3, 2] + 2 * C[3, 1]) * C[4, 2] * C[3, 3] +
+                   C[3, 2]^2 * C[4, 3]) / C[3, 1]
+    else
+        C[4, 1] = 1
+        C[3, 1] = 1
+        C[2, 1] = 2 * C[4, 2]
+    end
+    # running calculations to n-1 (not executed if n = 2)
+    for m in 2:L
+        g = -C[3, m+1] / C[4, m-1]
+        C[2, m] = g * C[2, m-1] + 3 * (C[3, m] * C[4, m+1] + C[3, m+1] * C[4, m])
+        C[4, m] = g * C[3, m-1] + 2 * (C[3, m] + C[3, m+1])
+    end
+    # ending boundary condition (IBCEND = 0)
+    local g::Complex{T} = 0
+    if n == 2       # (N==2 .AND. IBCBEG==0)
+        C[2, n] = C[4, n]
+    elseif n == 3   # (N==3 .AND. IBCBEG==0)
+        C[2, n] = 2 * C[4, n]
+        C[4, n] = 1
+        g = -1 / C[4, n-1]
+    else
+        g = C[3, n-1] + C[3, n]
+        C[2, n] = ((C[3, n] + 2 * g) * C[4, n] * C[3, n-1] +
+                   C[3, n]^2 * (C[1, n-1] - C[1, n-2]) / C[3, n-1]) / g
+        g = -g / C[4, n-1]
+        C[4, n] = C[3, n-1]
+    end
+    if n > 2
+        C[4, n] = g * C[3, n-1] + C[4, n]
+        C[2, n] = (g * C[2, n-1] + C[2, n]) / C[4, n]
+    end
+    # back substitution
+    for j in L:-1:1
+        C[2, j] = (C[2, j] - C[3, j] * C[2, j+1]) / C[4, j]
+    end
+    # final calculations
+    for i in 2:n
+        dtau = C[3, i]
+        divdf1 = (C[1, i] - C[1, i-1]) / dtau
+        divdf3 = C[2, i-1] + C[2, i] - 2 * divdf1
+        C[3, i-1] = 2 * (divdf1 - C[2, i-1] - divdf3) / dtau
+        C[4, i-1] = (divdf3 / dtau) * (6 / dtau)
+    end
+    # curvature at the last node & mean value (unused by evaluation; kept for parity)
+    C[3, n] = C[3, L] + (tau[n] - tau[L]) * C[4, L]
+    C[4, n] = 0
+    C
+end
+
+function SplineSSP(z::AbstractVector, c::AbstractVector)
+    T = float(promote_type(eltype(z), real(eltype(c))))
+    zv = collect(T, z)
+    cv = collect(Complex{T}, c)
+    issorted(zv) || throw(ArgumentError("SSP depths must be increasing"))
+    length(zv) ≥ 2 || throw(ArgumentError("SSP needs at least 2 points"))
+    SplineSSP{T}(zv, cspline_coefs(zv, cv))
+end
+
+@inline function evaluate(s::SplineSSP{T}, zq, tz, iseg::Int) where {T}
+    i = update_seg(s.z, zq, tz, iseg)
+    h = zq - s.z[i]
+    # SPLINEALL (misc/splinec.f90)
+    f   = s.coef[1, i] + h * (s.coef[2, i] + h * (s.coef[3, i] / 2 + h * s.coef[4, i] / 6))
+    fx  = s.coef[2, i] + h * (s.coef[3, i] + h * s.coef[4, i] / 2)
+    fxx = s.coef[3, i] + h * s.coef[4, i]
+    SSPEval(real(f), imag(f), real(fx), real(fxx)), i
+end

--- a/src/bellhopjl/step.jl
+++ b/src/bellhopjl/step.jl
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Bellhop's modified midpoint stepper. Ports Step2D, ReduceStep2D and
+# StepToBdry2D (Step.f90, A-New-BellHope 2022_4 layout including the
+# boundary-snapping overhaul described in its README).
+
+"""
+    reduce_step2d(env, x0, urayt, iSegz0, topg, botg, box, deltas, h) -> (h, small)
+
+Reduce trial step `h` along the unscaled tangent `urayt` so the step lands on
+the nearest of: SSP depth-interface, ray box, top/bottom boundary, or
+boundary-segment range interval. Ports `ReduceStep2D` (Step.f90).
+"""
+function reduce_step2d(env::Env2D, x0::SVector{2,T}, urayt::SVector{2,T},
+                       iSegz0::Int, topg, botg, box, deltas, h) where {T}
+    x = x0 + h * urayt
+    hbig = T(Inf)
+
+    # interface crossing in depth
+    hInt = hbig
+    zs = env.ssp.z
+    if abs(urayt[2]) > eps(T)
+        if zs[iSegz0] > x[2]
+            hInt = (zs[iSegz0] - x0[2]) / urayt[2]
+        elseif zs[iSegz0 + 1] < x[2]
+            hInt = (zs[iSegz0 + 1] - x0[2]) / urayt[2]
+        end
+    end
+
+    # ray box (centred at (0,0))
+    hBoxr = hbig
+    if abs(x[1]) > box.r
+        hBoxr = (box.r - abs(x0[1])) / abs(urayt[1])
+    end
+    hBoxz = hbig
+    if abs(x[2]) > box.z
+        hBoxz = (box.z - abs(x0[2])) / abs(urayt[2])
+    end
+
+    # top crossing
+    hTop = hbig
+    d = x - topg.x
+    if dot(topg.n, d) >= 0
+        d0 = x0 - topg.x
+        hTop = -dot(d0, topg.n) / dot(urayt, topg.n)
+    end
+
+    # bottom crossing
+    hBot = hbig
+    d = x - botg.x
+    if dot(botg.n, d) >= 0
+        d0 = x0 - botg.x
+        hBot = -dot(d0, botg.n) / dot(urayt, botg.n)
+    end
+
+    # top or bottom segment crossing in range
+    rSeg1 = max(topg.rseg[1], botg.rseg[1])
+    rSeg2 = min(topg.rseg[2], botg.rseg[2])
+    hSeg = hbig
+    if abs(urayt[1]) > eps(T)
+        if x[1] < rSeg1
+            hSeg = -(x0[1] - rSeg1) / urayt[1]
+        elseif x[1] > rSeg2
+            hSeg = -(x0[1] - rSeg2) / urayt[1]
+        end
+    end
+
+    h = min(h, hInt, hBoxr, hBoxz, hTop, hBot, hSeg)
+    small = false
+    if h < T(INFINITESIMAL_STEP_SIZE) * deltas
+        h = T(INFINITESIMAL_STEP_SIZE) * deltas
+        small = true
+    end
+    h, small
+end
+
+"""
+    step_to_bdry2d(env, x0, urayt, iSegz0, topg, botg, box, deltas) ->
+        (h, x2, topRefl, botRefl)
+
+Take the blended tangent and find the minimum step size to put the ray exactly
+on a boundary. Ports `StepToBdry2D` (Step.f90), including the exact snapping
+to flat boundaries and the reflection flags.
+"""
+function step_to_bdry2d(env::Env2D, x0::SVector{2,T}, urayt::SVector{2,T},
+                        iSegz0::Int, topg, botg, box, deltas) where {T}
+    h = deltas
+    x2 = x0 + h * urayt
+
+    # interface crossing in depth
+    zs = env.ssp.z
+    if abs(urayt[2]) > eps(T)
+        if zs[iSegz0] > x2[2]
+            h = (zs[iSegz0] - x0[2]) / urayt[2]
+            x2 = SVector(x0[1] + h * urayt[1], zs[iSegz0])
+        elseif zs[iSegz0 + 1] < x2[2]
+            h = (zs[iSegz0 + 1] - x0[2]) / urayt[2]
+            x2 = SVector(x0[1] + h * urayt[1], zs[iSegz0 + 1])
+        end
+    end
+
+    # ray box
+    if abs(x2[1]) > box.r
+        h = (box.r - abs(x0[1])) / abs(urayt[1])
+        x2 = SVector(copysign(box.r, x0[1]), x0[2] + h * urayt[2])
+    end
+    if abs(x2[2]) > box.z
+        h = (box.z - abs(x0[2])) / abs(urayt[2])
+        x2 = SVector(x0[1] + h * urayt[1], copysign(box.z, x0[2]))
+    end
+
+    # top crossing
+    topRefl = false
+    d = x2 - topg.x
+    if dot(topg.n, d) > -T(INFINITESIMAL_STEP_SIZE)
+        d0 = x0 - topg.x
+        h = -dot(d0, topg.n) / dot(urayt, topg.n)
+        x2 = x0 + h * urayt
+        if abs(topg.n[1]) < eps(T)                  # snap to exact depth if flat
+            x2 = SVector(x2[1], topg.x[2])
+        end
+        topRefl = true
+    end
+
+    # bottom crossing
+    botRefl = false
+    d = x2 - botg.x
+    if dot(botg.n, d) > -T(INFINITESIMAL_STEP_SIZE)
+        d0 = x0 - botg.x
+        h = -dot(d0, botg.n) / dot(urayt, botg.n)
+        x2 = x0 + h * urayt
+        if abs(botg.n[1]) < eps(T)
+            x2 = SVector(x2[1], botg.x[2])
+        end
+        botRefl = true
+        topRefl = false
+    end
+
+    # top or bottom segment crossing in range
+    rSeg1 = max(topg.rseg[1], botg.rseg[1])
+    rSeg2 = min(topg.rseg[2], botg.rseg[2])
+    if abs(urayt[1]) > eps(T)
+        if x2[1] < rSeg1
+            h = -(x0[1] - rSeg1) / urayt[1]
+            x2 = SVector(rSeg1, x0[2] + h * urayt[2])
+            topRefl = false
+            botRefl = false
+        elseif x2[1] > rSeg2
+            h = -(x0[1] - rSeg2) / urayt[1]
+            x2 = SVector(rSeg2, x0[2] + h * urayt[2])
+            topRefl = false
+            botRefl = false
+        end
+    end
+
+    if h < T(INFINITESIMAL_STEP_SIZE) * deltas       # infinitesimal step
+        h = T(INFINITESIMAL_STEP_SIZE) * deltas
+        x2 = x0 + h * urayt
+        # recheck reflection conditions
+        topRefl = dot(topg.n, x2 - topg.x) > eps(T)
+        botRefl = dot(botg.n, x2 - botg.x) > eps(T)
+        botRefl && (topRefl = false)
+    end
+    h, x2, topRefl, botRefl
+end
+
+@inline cnn_csq(e::SSPEval, t::SVector{2}) = e.czz * t[1]^2
+# (crr·t₂² − 2·crz·t₁·t₂ + czz·t₁² with crr = crz = 0 for range-independent SSP)
+
+"""
+    step2d(env, ray0, iSegz, topg, botg, box, deltas) ->
+        (ray2, iSegz2, topRefl, botRefl, small)
+
+One Bellhop integration step. Ports `Step2D` (Step.f90): reduced half-Euler to
+the midpoint, second `reduce_step2d` with midpoint derivatives, weighted
+update via `step_to_bdry2d`, then the SSP interface jump condition on `p`.
+"""
+function step2d(env::Env2D, ray0::RayPt{T}, iSegz::Int, topg, botg, box,
+                deltas) where {T}
+    # phase 1 (Euler half step)
+    e0, iSegz = evalssp(env, ray0.x, ray0.t, iSegz)
+    c0 = e0.c
+    csq0 = c0 * c0
+    cnn0_csq0 = cnn_csq(e0, ray0.t)
+    iSegz0 = iSegz
+    gradc0 = SVector(zero(e0.cz), e0.cz)
+
+    h = deltas
+    urayt0 = c0 * ray0.t
+    h, small1 = reduce_step2d(env, ray0.x, urayt0, iSegz0, topg, botg, box, deltas, h)
+    halfh = h / 2
+
+    x1 = ray0.x + halfh * urayt0
+    t1 = ray0.t - halfh * gradc0 / csq0
+    p1 = ray0.p - halfh * cnn0_csq0 * ray0.q
+    q1 = ray0.q + halfh * c0 * ray0.p
+
+    # phase 2
+    e1, iSegz = evalssp(env, x1, t1, iSegz)
+    c1 = e1.c
+    csq1 = c1 * c1
+    cnn1_csq1 = cnn_csq(e1, t1)
+    gradc1 = SVector(zero(e1.cz), e1.cz)
+
+    urayt1 = c1 * t1
+    h, small2 = reduce_step2d(env, ray0.x, urayt1, iSegz0, topg, botg, box, deltas, h)
+
+    # blend of f' based on proportion of a full step used
+    w1 = h / (2 * halfh)
+    w0 = 1 - w1
+    urayt2   =  w0 * urayt0 + w1 * urayt1
+    unitdt   = -w0 * gradc0 / csq0 - w1 * gradc1 / csq1
+    unitdp   = -w0 * cnn0_csq0 * ray0.q - w1 * cnn1_csq1 * q1
+    unitdq   =  w0 * c0 * ray0.p + w1 * c1 * p1
+    unitdtau =  w0 / complex(c0, e0.cimag) + w1 / complex(c1, e1.cimag)
+
+    h, x2, topRefl, botRefl =
+        step_to_bdry2d(env, ray0.x, urayt2, iSegz0, topg, botg, box, deltas)
+    t2 = ray0.t + h * unitdt
+    p2 = ray0.p + h * unitdp
+    q2 = ray0.q + h * unitdq
+    τ2 = ray0.τ + h * unitdtau
+
+    e2, iSegz = evalssp(env, x2, t2, iSegz)
+
+    # if we crossed an interface, apply jump condition on p
+    if iSegz != iSegz0 && !iszero(t2[2])
+        gradcjump = SVector(zero(e2.cz), e2.cz - e0.cz)
+        ray2n = SVector(-t2[2], t2[1])
+        cnjump = dot(gradcjump, ray2n)
+        csjump = dot(gradcjump, t2)
+        RM = t2[1] / t2[2]                # crossing in depth
+        RN = RM * (2 * cnjump - RM * csjump) / e2.c
+        p2 = p2 - q2 * RN
+    end
+
+    ray2 = RayPt{T}(x2, t2, p2, q2, τ2, e2.c, ray0.amp, ray0.phase,
+                    ray0.ntop, ray0.nbot)
+    ray2, iSegz, topRefl, botRefl, small1 | small2
+end

--- a/src/bellhopjl/step.jl
+++ b/src/bellhopjl/step.jl
@@ -224,7 +224,9 @@ function step2d(env::Env2D, ray0::RayPt{T}, iSegz::Int, topg, botg, box,
     e2, iSegz = evalssp(env, x2, t2, iSegz)
 
     # if we crossed an interface, apply jump condition on p
-    if iSegz != iSegz0 && !iszero(t2[2])
+    # (OALIB 2024 Step2D, Step.f90: only for SSPs with a discontinuous first
+    # derivative — 'N'/'C'; spline/PCHIP/analytic profiles are C¹ and get none)
+    if has_gradcjump(env.ssp) && iSegz != iSegz0 && !iszero(t2[2])
         gradcjump = SVector(zero(e2.cz), e2.cz - e0.cz)
         ray2n = SVector(-t2[2], t2[1])
         cnjump = dot(gradcjump, ray2n)

--- a/src/bellhopjl/trace.jl
+++ b/src/bellhopjl/trace.jl
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Ray tracing and boundary reflection. Ports TraceRay2D and Reflect2D
+# (bellhop.f90).
+
+"""
+    reflect2d(env, ray, bc, tBdry, nBdry, κ, ω, iSegz, is_top) -> (RayPt, iSegz)
+
+Specular reflection at a boundary with unit tangent `tBdry`, outward unit
+normal `nBdry` and curvature `κ`. Ports `Reflect2D` (bellhop.f90) with the
+default beam type `Beam%Type(3:3) = 'S'` (standard curvature condition — no
+doubling/zeroing) and no beam shift.
+"""
+function reflect2d(env::Env2D, ray::RayPt{T}, bc::BoundaryCondition,
+                   tBdry::SVector{2}, nBdry::SVector{2}, κ, ω, iSegz::Int,
+                   is_top::Bool) where {T}
+    Tg = dot(ray.t, tBdry)      # component of ray tangent along boundary
+    Th = dot(ray.t, nBdry)      # component of ray tangent normal to boundary
+
+    t′ = ray.t - 2 * Th * nBdry  # reflected (scaled) tangent
+
+    # curvature correction, based on Muller, Geoph. J. R.A.S., 79 (1984)
+    e, iSegz = evalssp(env, ray.x, ray.t, iSegz)   # just to get c
+    c = e.c
+    gradc = SVector(zero(e.cz), e.cz)
+
+    rayt = c * ray.t                           # incident unit tangent
+    rayn = SVector(-rayt[2], rayt[1])          # incident unit normal
+    rayt_tilde = c * t′                        # reflected unit tangent
+    rayn_tilde = -SVector(-rayt_tilde[2], rayt_tilde[1])  # reflected unit normal
+
+    RN = 2 * κ / c^2 / Th                      # boundary curvature correction
+
+    cnjump = -dot(gradc, rayn_tilde - rayn)
+    csjump = -dot(gradc, rayt_tilde - rayt)
+
+    if is_top
+        cnjump = -cnjump   # (t,n) system of the top boundary has opposite sense
+        RN = -RN
+    end
+
+    RM = Tg / Th           # tan(angle of incidence)
+    RN = RN + RM * (2 * cnjump - RM * csjump) / c^2
+    # Beam%Type(3:3) = 'S' (default): standard curvature condition (no scaling)
+
+    p′ = ray.p + ray.q * RN
+    q′ = ray.q
+
+    aR, φR = reflection_coefficient(bc, Tg, Th, ω)
+    amp′ = iszero(aR) ? zero(ray.amp) : aR * ray.amp
+    phase′ = ray.phase + φR
+
+    RayPt{T}(ray.x, t′, p′, q′, ray.τ, c, amp′, phase′,
+             ray.ntop + (is_top ? 1 : 0), ray.nbot + (is_top ? 0 : 1)), iSegz
+end
+
+"""
+    trace_ray(env, α, zs, beam; amp0=1) -> Vector{RayPt}
+
+Trace the beam with take-off angle `α` [rad, positive down] from the source at
+(0, zs). Ports `TraceRay2D` (bellhop.f90). At each boundary reflection two
+coincident points are stored (incoming and outgoing tangents), as in the
+Fortran.
+"""
+function trace_ray(env::Env2D, α, zs, beam::BeamParams; amp0=1)
+    T = promote_type(env_eltype(env), typeof(float(α)), typeof(float(zs)),
+                     typeof(beam.deltas), typeof(float(amp0)))
+    ω = 2π * env.freq
+    deltas = T(beam.deltas)
+    box = (r = T(beam.box_r), z = T(beam.box_z))
+
+    iSegz = 1
+    xs = SVector{2,T}(zero(T), T(zs))
+    tinit = SVector{2,T}(cos(α), sin(α))
+    e0, iSegz = evalssp(env, xs, tinit, iSegz)
+
+    ray = RayPt{T}(xs, tinit / e0.c, SVector{2,T}(1, 0), SVector{2,T}(0, 0),
+                   zero(Complex{T}), e0.c, T(amp0), zero(T), 0, 0)
+    # q initialised to (0,0): TraceRay2D sets q = 0 for geometric beam runs
+    # ('G'); the (p₂,q₂) plane-wave pair is decoupled from (p₁,q₁) and unused
+    # by the geometric influence functions, so this also matches 'B' runs.
+    hist = Vector{RayPt{T}}()
+    sizehint!(hist, 2000)
+    push!(hist, ray)
+
+    iTop = get_seg(env.top, xs[1], ray.t[1])
+    iBot = get_seg(env.bot, xs[1], ray.t[1])
+    topg = segment_geom(env.top, iTop)
+    botg = segment_geom(env.bot, iBot)
+
+    distBegTop, distBegBot = distances(ray.x, topg, botg)
+    if distBegTop <= 0 || distBegBot <= 0
+        return hist   # source on or outside the boundaries
+    end
+
+    while true
+        ray, iSegz, topRefl, botRefl, _ =
+            step2d(env, ray, iSegz, topg, botg, box, deltas)
+        push!(hist, ray)
+
+        # new altimetry segment?
+        r = ray.x[1]
+        if r < topg.rseg[1] || (r == topg.rseg[1] && ray.t[1] < 0) ||
+           r > topg.rseg[2] || (r == topg.rseg[2] && ray.t[1] >= 0)
+            iTop = get_seg(env.top, r, ray.t[1])
+            topg = segment_geom(env.top, iTop)
+        end
+        # new bathymetry segment?
+        if r < botg.rseg[1] || (r == botg.rseg[1] && ray.t[1] < 0) ||
+           r > botg.rseg[2] || (r == botg.rseg[2] && ray.t[1] >= 0)
+            iBot = get_seg(env.bot, r, ray.t[1])
+            botg = segment_geom(env.bot, iBot)
+        end
+
+        distEndTop, distEndBot = distances(ray.x, topg, botg)
+
+        if topRefl
+            ray, iSegz = reflect2d(env, ray, env.topbc, topg.t, topg.n, topg.κ,
+                                   ω, iSegz, true)
+            push!(hist, ray)
+            distEndTop, distEndBot = distances(ray.x, topg, botg)
+        elseif botRefl
+            ray, iSegz = reflect2d(env, ray, env.botbc, botg.t, botg.n, botg.κ,
+                                   ω, iSegz, false)
+            push!(hist, ray)
+            distEndTop, distEndBot = distances(ray.x, topg, botg)
+        end
+
+        # has the ray left the box, lost its energy, or escaped the boundaries?
+        if abs(ray.x[1]) >= box.r || abs(ray.x[2]) >= box.z ||
+           ray.amp < T(0.005) ||
+           (distBegTop < 0 && distEndTop < 0) ||
+           (distBegBot < 0 && distEndBot < 0) ||
+           length(hist) >= MAX_N - 3
+            break
+        end
+
+        distBegTop = distEndTop
+        distBegBot = distEndBot
+    end
+    hist
+end

--- a/src/bellhopjl/types.jl
+++ b/src/bellhopjl/types.jl
@@ -40,9 +40,9 @@ end
 
 @enum RunMode COHERENT INCOHERENT SEMICOHERENT ARRIVALS
 
-# bellhopMod.f90: MaxN = 100000 (max # of steps along a ray);
+# bellhopMod.f90 (OALIB 2024): MaxN = 1000000 (max # of steps along a ray);
 # TraceRay2D exits at is >= MaxN - 3.
-const MAX_N = 100_000
+const MAX_N = 1_000_000
 
 # Step.f90: INFINITESIMAL_STEP_SIZE = 1.0d-6
 const INFINITESIMAL_STEP_SIZE = 1.0e-6

--- a/src/bellhopjl/types.jl
+++ b/src/bellhopjl/types.jl
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+    RayPt{T}
+
+State of one point along a ray. Mirrors `ray2DPt` in `bellhopMod.f90`.
+
+- `x` — position (r, z), z positive down [m]
+- `t` — *scaled* tangent, `t = unit_tangent / c` (so `|t| = 1/c`) [s/m]
+- `p, q` — dynamic ray-tracing quantities; initial conditions p=(1,0), q=(0,1)
+  (geometric beams use only the first component and start with q=(0,0))
+- `τ` — complex travel time; imaginary part accumulates volume attenuation
+- `c` — sound speed at `x` [m/s]
+- `amp`, `phase` — ray amplitude and accumulated phase from boundary reflections
+- `ntop`, `nbot` — boundary bounce counters
+"""
+struct RayPt{T<:Real}
+    x::SVector{2,T}
+    t::SVector{2,T}
+    p::SVector{2,T}
+    q::SVector{2,T}
+    τ::Complex{T}
+    c::T
+    amp::T
+    phase::T
+    ntop::Int
+    nbot::Int
+end
+
+"Beam/run configuration. Mirrors the `Beam` structure in `bellhopMod.f90`."
+Base.@kwdef struct BeamParams{T<:Real}
+    deltas::T                 # step size [m] (0 not allowed here; resolved by caller)
+    box_r::T                  # ray box max range [m]
+    box_z::T                  # ray box max depth [m]
+    nbeams::Int
+    αmin::T                   # take-off angle limits [rad], positive down
+    αmax::T
+    gaussian::Bool = false    # false ⇒ geometric hat ('G'), true ⇒ Gaussian ('B')
+end
+
+@enum RunMode COHERENT INCOHERENT SEMICOHERENT ARRIVALS
+
+# bellhopMod.f90: MaxN = 100000 (max # of steps along a ray);
+# TraceRay2D exits at is >= MaxN - 3.
+const MAX_N = 100_000
+
+# Step.f90: INFINITESIMAL_STEP_SIZE = 1.0d-6
+const INFINITESIMAL_STEP_SIZE = 1.0e-6
+
+# bdryMod.f90 / ComputeBdryTangentNormal: boundaries are extended to
+# ±sqrt(huge)/1e5 in range
+const BDRY_BIG = sqrt(floatmax(Float64)) / 1.0e5

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,8 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"

--- a/test/test_bellhopjl.jl
+++ b/test/test_bellhopjl.jl
@@ -1,0 +1,162 @@
+using TestItems
+
+# Tests for the BellhopJL solver (src/bellhopjl/, GPL-3.0-or-later).
+# Golden reference constants below were generated from the Fortran Bellhop
+# (AcousticsToolbox_jll, OALIB build) via the Bellhop wrapper in this package.
+
+@testitem "bellhopjl-models" begin
+  using UnderwaterAcoustics
+  m = models()
+  @test BellhopJL ∈ m
+  env = UnderwaterEnvironment(bathymetry = 20.0u"m")
+  pm = BellhopJL(env)
+  @test pm isa BellhopJL
+  @test_throws ErrorException BellhopJL(env; min_angle = 0.0, max_angle = 0.0)
+  @test_throws ErrorException BellhopJL(env; beam_type = :cerveny)
+end
+
+@testitem "bellhopjl-arrivals" begin
+  using UnderwaterAcoustics
+  using UnderwaterAcoustics: distance
+  # Pekeris golden scenario: 100 m deep, sand seabed, 500 Hz, tx at 25 m
+  env = UnderwaterEnvironment(bathymetry = 100.0, soundspeed = 1500.0,
+    seabed = FluidBoundary(1900.0, 1650.0, 0.0))
+  pm = BellhopJL(env)
+  tx = AcousticSource(0.0, -25.0, 500.0)
+  rx = AcousticReceiver(1000.0, -60.0)
+  arr = arrivals(pm, tx, rx)
+  @test arr isa AbstractArray{<:UnderwaterAcoustics.RayArrival}
+  @test length(arr) ≥ 10
+  @test all([arr[j].t ≥ arr[j-1].t for j ∈ 2:length(arr)])
+  # golden (Fortran) reference: first arrivals at r=1000, z=-60
+  @test arr[1].t ≈ 0.66707480 atol=1e-5
+  @test arr[2].t ≈ 0.66907066 atol=1e-5
+  @test arr[3].t ≈ 0.67106044 atol=1e-5
+  @test [(arr[j].ns, arr[j].nb) for j ∈ 1:4] == [(0,0), (1,0), (0,1), (1,1)]
+  @test abs(arr[1].ϕ) ≈ 9.9763e-4 rtol=0.01     # direct path, ≈ 1/r
+  @test real(arr[2].ϕ) < 0                      # surface bounce flips phase
+  @test abs(arr[3].ϕ) ≈ hypot(-5.42729563e-4, 8.29995896e-4) rtol=0.02
+  @test arr[1].θₛ ≈ -0.034986 atol=1e-4
+  @test arr[1].θᵣ ≈ 0.034986 atol=1e-4
+  # eigenray paths
+  @test all([a.path[1] == (x=0.0, y=0.0, z=-25.0) for a ∈ arr])
+  @test all([distance(a.path[end], (x=1000.0, y=0.0, z=-60.0)) < 20.0 for a ∈ arr[1:4]])
+end
+
+@testitem "bellhopjl-field" begin
+  using UnderwaterAcoustics
+  # deep isovelocity water, single direct path: |p| ≈ 1/r
+  env = UnderwaterEnvironment(bathymetry = 5000.0, soundspeed = 1500.0,
+    seabed = FluidBoundary(water_density(), 1500.0, 0.0))
+  pm = BellhopJL(env; min_angle = -30°, max_angle = 30°)
+  tx = AcousticSource((x=0.0, z=-2500.0), 300.0)
+  x = acoustic_field(pm, tx, AcousticReceiver((x=1000.0, z=-2500.0)))
+  @test x isa Complex
+  @test abs(x) ≈ 1/1000 rtol=0.02
+  x′ = acoustic_field(pm, tx, AcousticReceiver((x=1000.0, z=-2500.0)); mode=:incoherent)
+  @test abs(x′) ≈ 1/1000 rtol=0.02
+  y = transmission_loss(pm, tx, AcousticReceiver((x=1000.0, z=-2500.0)))
+  @test -20 * log10(abs(x)) ≈ y atol=0.1
+end
+
+@testitem "bellhopjl-pekeris-tl" begin
+  using UnderwaterAcoustics
+  # golden (Fortran Bellhop) TL values on the Pekeris scenario grid
+  env = UnderwaterEnvironment(bathymetry = 100.0, soundspeed = 1500.0,
+    seabed = FluidBoundary(1900.0, 1650.0, 0.0))
+  tx = AcousticSource(0.0, -25.0, 500.0)
+  rxs = AcousticReceiverGrid2D(range(200.0, 5000.0; length=120),
+                               range(-95.0, -5.0; length=45))
+  pm = BellhopJL(env)
+  xloss = transmission_loss(pm, tx, rxs)
+  @test size(xloss) == (120, 45)
+  @test xloss[10, 10] ≈ 49.1411 atol=0.1     # r=563 m,  z=-76.6 m
+  @test xloss[50, 20] ≈ 53.5504 atol=0.1     # r=2176 m, z=-56.1 m
+  @test xloss[100, 40] ≈ 56.6454 atol=0.1    # r=4193 m, z=-15.2 m
+  xloss′ = transmission_loss(pm, tx, rxs; mode=:incoherent)
+  @test xloss′[10, 10] ≈ 47.8685 atol=0.1
+  @test xloss′[50, 20] ≈ 54.0370 atol=0.1
+  @test xloss′[30, 5] ≈ 52.1272 atol=0.1
+end
+
+@testitem "bellhopjl-munk-tl" begin
+  using UnderwaterAcoustics
+  # Munk spline-SSP profile, Gaussian beams, incoherent TL vs Fortran golden
+  munk(z) = 1500 * (1 + 0.00737 * (2 * (z - 1300) / 1300 - 1 + exp(-2 * (z - 1300) / 1300)))
+  zvals = 0.0:250.0:5000.0
+  ssp = SampledField(munk.(zvals); z=-zvals, interp=CubicSpline())
+  env = UnderwaterEnvironment(bathymetry = 5000.0, soundspeed = ssp,
+    seabed = FluidBoundary(1900.0, 1650.0, 0.0))
+  tx = AcousticSource(0.0, -1000.0, 50.0)
+  rxs = AcousticReceiverGrid2D(range(1000.0, 60_000.0; length=150),
+                               range(-4900.0, -100.0; length=49))
+  pm = BellhopJL(env; beam_type = :gaussian)
+  xloss = transmission_loss(pm, tx, rxs; mode=:incoherent)
+  @test size(xloss) == (150, 49)
+  @test xloss[10, 10] ≈ 72.0804 atol=0.5     # r=4.6 km,  z=-4000 m
+  @test xloss[50, 20] ≈ 80.3815 atol=0.5     # r=20.4 km, z=-3000 m
+  @test xloss[100, 40] ≈ 80.4499 atol=0.5    # r=40.2 km, z=-1000 m
+  @test xloss[30, 5] ≈ 77.0737 atol=0.5      # r=12.5 km, z=-4500 m
+end
+
+@testitem "bellhopjl-analytic-ray" begin
+  # linear soundspeed gradient ⇒ circular-arc rays (internal API)
+  using AcousticsToolbox.BellhopJLCore: CLinearSSP, Env2D, BeamParams,
+    flat_boundary, VacuumBC, RigidBC, trace_ray
+  c0, g, depth = 1500.0, 0.05, 5000.0
+  ssp = CLinearSSP([0.0, depth], [c0, c0 + g * depth])
+  env = Env2D(100.0, ssp, flat_boundary(0.0; top=true),
+              flat_boundary(depth; top=false), VacuumBC(), RigidBC())
+  beam = BeamParams(deltas=10.0, box_r=3000.0, box_z=depth, nbeams=1,
+                    αmin=0.0, αmax=0.0)
+  z0, θ0 = 1000.0, deg2rad(-5)
+  ray = trace_ray(env, θ0, z0, beam)
+  R = (c0 + g * z0) / (g * cos(θ0))
+  xc, zc = R * sin(θ0), z0 - R * cos(θ0)
+  for pt ∈ ray[2:10:end]
+    @test hypot(pt.x[1] - xc, pt.x[2] - zc) ≈ R rtol=2e-4
+  end
+  # isovelocity: exact travel time
+  env2 = Env2D(100.0, CLinearSSP([0.0, depth], [c0, c0]),
+               flat_boundary(0.0; top=true), flat_boundary(depth; top=false),
+               VacuumBC(), RigidBC())
+  ray2 = trace_ray(env2, deg2rad(10), 2500.0, beam)
+  for pt ∈ ray2
+    s = hypot(pt.x[1], pt.x[2] - 2500.0)
+    @test real(pt.τ) ≈ s / c0 atol=1e-12
+  end
+end
+
+@testitem "∂bellhopjl" begin
+  using UnderwaterAcoustics
+  using DifferentiationInterface
+  import ForwardDiff, FiniteDifferences
+  fd = AutoFiniteDifferences(fdm=FiniteDifferences.central_fdm(5, 1))
+  function ℳ((D, R, d1, d2, f, c))
+    env = UnderwaterEnvironment(bathymetry = D, soundspeed = c, seabed = SandySilt)
+    pm = BellhopJL(env; beam_type = :gaussian, nbeams = 100)
+    transmission_loss(pm, AcousticSource((x=0.0, z=-d1), f), AcousticReceiver((x=R, z=-d2)))
+  end
+  x = [20.0, 100.0, 5.0, 10.0, 5000.0, 1500.0]
+  @test gradient(ℳ, AutoForwardDiff(), x) ≈ gradient(ℳ, fd, x) atol=1e-3
+end
+
+@testitem "bellhopjl-vs-bellhop" begin
+  using UnderwaterAcoustics
+  using Statistics
+  # both models live in this package: incoherent TL on a Pekeris grid must
+  # agree closely (amplitude-only comparison, robust to stepping differences)
+  env = UnderwaterEnvironment(bathymetry = 100.0, soundspeed = 1500.0,
+    seabed = FluidBoundary(1900.0, 1650.0, 0.0))
+  tx = AcousticSource(0.0, -25.0, 500.0)
+  rxs = AcousticReceiverGrid2D(range(200.0, 5000.0; length=60),
+                               range(-95.0, -5.0; length=23))
+  tl1 = transmission_loss(BellhopJL(env), tx, rxs; mode=:incoherent)
+  tl2 = transmission_loss(Bellhop(env), tx, rxs; mode=:incoherent)
+  @test size(tl1) == size(tl2)
+  @test median(abs.(tl1 .- tl2)) < 0.1
+  # coherent fields should also agree tightly on this scenario
+  tl1c = transmission_loss(BellhopJL(env), tx, rxs)
+  tl2c = transmission_loss(Bellhop(env), tx, rxs)
+  @test median(abs.(tl1c .- tl2c)) < 0.1
+end


### PR DESCRIPTION
Adds `BellhopJL`, a native Julia port of the 2D BELLHOP Gaussian-beam/ray model, alongside the existing Fortran-wrapping `Bellhop` — no env files, no subprocess, ForwardDiff-differentiable end to end. Based on `compat-uwa-0.8` (targets the UWA 0.8 API); intended to merge after #18 lands.

```julia
pm = BellhopJL(env; nbeams=0, min_angle=-80°, max_angle=80°, beam_type=:geometric)  # or :gaussian
```

## Provenance

Full details in [`src/bellhopjl/PORTING_NOTES.md`](../blob/feat-bellhopjl/src/bellhopjl/PORTING_NOTES.md); summary:

- **Base**: BELLHOP 2D from OALIB Acoustics Toolbox **2022_4**, ported via the [A-New-BellHope](https://github.com/A-New-BellHope/bellhop) mirror *including* its documented bug fixes. Docstrings cite the originating Fortran file/subroutine throughout, so the code stays diffable against upstream.
- **Deliberately retained A-New-BellHope deviations from stock OALIB** (they fix the reproducibility problem where every reduced step lands on a floating-point edge case at boundaries): exact boundary landing (`StepToBdry2D`), tangent-aware boundary-segment selection, the tighter small-step scheme, and the shallow-angle threshold.
- **Adopted OALIB 2024_12_25 corrections** (commit `adb2a85`, verified no measurable golden impact): additive caustic phase in the geometric influence functions (`phaseInt += π/2` — the 2D bug OALIB fixed by 2024), Gaussian influence reading ray phase from the previous point, the SSP-interface p-jump gated off for C¹ (spline/PCHIP/analytic) profiles, and `MaxN` 100k → 1M.
- **Other intentional deviations** (all listed in PORTING_NOTES.md): no file I/O, simplified per-step receiver search, scope exclusions (Cerveny/SGB/ray-centered/3D), AD-driven coding constraints.
- **Validation provenance**: golden references generated with `AcousticsToolbox_jll` v2025.9.6, which is built from the SHA-pinned `at_2024_12_25.zip` — i.e. the goldens already include the 2024 corrections above. Golden TL median ≤ 0.002 dB on non-spline scenarios (0.02 dB Munk-spline incoherent); an in-process `bellhopjl-vs-bellhop` consistency testitem asserts median |ΔTL| < 0.1 dB on a Pekeris grid in both modes; `∂bellhopjl` gates ForwardDiff against finite differences. Known residual: Munk *coherent* fields differ from the Fortran at the ~2.5 dB pointwise level — attributable to the retained A-New-BellHope stepping (documented, comparable to BELLHOP's own 601-vs-600-beam sensitivity).

## Tests / deps / licensing

- Full suite 528/528 incl. Aqua and all existing Bellhop/Kraken/Orca tests; runs the Munk 50 Hz grid ~25% faster than the wrapped Fortran.
- Adds StaticArrays and LinearAlgebra only. Version bumped to 0.8.0.
- BELLHOP is GPL, so the port is a derivative work: `src/bellhopjl/**` is GPL-3.0 (per-file SPDX headers; full text in `LICENSE-GPL-3.0`); all existing code remains MIT. The README licensing section notes this package already downloads and executes GPL OALIB binaries via AcousticsToolbox_jll, and that distribution of the combined package is subject to GPL-3.0.

Docs page for the model: org-arl/UnderwaterAcoustics.jl#91.