### PR TITLE
Multithreaded beam loop and single-thread optimizations

### DIFF
--- a/src/bellhopjl/PORTING_NOTES.md
+++ b/src/bellhopjl/PORTING_NOTES.md
@@ -106,6 +106,23 @@ unchanged between 2022_4 and 2024_12_25.
   guard; the Fortran would divide by zero).
 - `AddArr` merges against the *last* arrival only, with `PhaseTol = 0.05` —
   Fortran behaviour retained for parity (flagged as a bug by A-New-BellHope).
+- **Ray-history buffer reuse** — `TraceRay2D`'s ray storage is a fresh
+  `Vector{RayPt}` per beam in the naive port; `trace_ray!` reuses one buffer
+  across the beam loop (the Fortran uses a single static `ray2D` array, so
+  this is actually *closer* to the original).
+- **Multithreaded beam loop** — the beam loop of `BellhopCore` is optionally
+  split into contiguous chunks across threads (`threads` kwarg of `BellhopJL`,
+  default `Threads.nthreads()`). Each chunk has its own field accumulator /
+  arrival sink; per-chunk fields are summed in chunk order (deterministic for
+  a fixed thread count, differs from serial only by floating-point
+  reassociation), and per-chunk arrival lists are replayed through `add_arr!`
+  in beam order to preserve the serial merge semantics. `threads=1` runs the
+  identical serial path.
+- **Eigenray retrace memoization** — `arrivals` traces each *unique* take-off
+  angle once when extracting ray paths (merged arrivals share angles); the
+  Fortran writes ray files in a separate run and has no equivalent step.
+- `@inbounds` on the influence receiver loop and SSP segment scan (bounds
+  are guaranteed by the monotone pointer walk / segment clamping).
 
 ## 4. Validation provenance
 

--- a/src/bellhopjl/api.jl
+++ b/src/bellhopjl/api.jl
@@ -25,6 +25,8 @@ Supported keyword arguments:
 - `min_angle`: minimum beam angle (default: -80°)
 - `max_angle`: maximum beam angle (default: 80°)
 - `beam_type`: `:geometric` (default) or `:gaussian`
+- `threads`: number of threads for the beam loop (default: `Threads.nthreads()`;
+  1 runs the serial code path)
 """
 struct BellhopJL{T} <: AbstractRayPropagationModel
     env::T
@@ -32,7 +34,8 @@ struct BellhopJL{T} <: AbstractRayPropagationModel
     min_angle::Float64      # [rad], UA convention (positive up)
     max_angle::Float64
     gaussian::Bool
-    function BellhopJL(env, nbeams, min_angle, max_angle, beam_type)
+    threads::Int
+    function BellhopJL(env, nbeams, min_angle, max_angle, beam_type, threads)
         env.seabed isa FluidBoundary ||
             error("seabed must be a FluidBoundary")
         env.surface isa FluidBoundary ||
@@ -43,13 +46,15 @@ struct BellhopJL{T} <: AbstractRayPropagationModel
         -π/2 ≤ max_angle ≤ π/2 || error("max_angle should be between -π/2 and π/2")
         min_angle < max_angle || error("max_angle should be more than min_angle")
         beam_type ∈ (:geometric, :gaussian) || error("Unknown beam_type type")
+        threads ≥ 1 || error("threads should be at least 1")
         new{typeof(env)}(env, max(nbeams, 0), Float64(min_angle),
-                         Float64(max_angle), beam_type === :gaussian)
+                         Float64(max_angle), beam_type === :gaussian, threads)
     end
 end
 
-BellhopJL(env; nbeams=0, min_angle=-80°, max_angle=80°, beam_type=:geometric) =
-    BellhopJL(env, nbeams, min_angle, max_angle, beam_type)
+BellhopJL(env; nbeams=0, min_angle=-80°, max_angle=80°, beam_type=:geometric,
+          threads=Threads.nthreads()) =
+    BellhopJL(env, nbeams, min_angle, max_angle, beam_type, threads)
 
 Base.show(io::IO, pm::BellhopJL) = print(io, "BellhopJL(⋯)")
 
@@ -175,7 +180,8 @@ function UnderwaterAcoustics.acoustic_field(pm::BellhopJL,
     rxz = [-z for z in rxs.zrange]
     maxr = maximum(rxs.xrange)
     env2d, zs, beam = _make_env2d(pm, tx, maxr)
-    U = pressure_field(env2d, zs, rxr, rxz, beam, runmode)   # (nz, nr)
+    U = pressure_field(env2d, zs, rxr, rxz, beam, runmode;
+                       ntasks=pm.threads)                    # (nz, nr)
     fld = -permutedims(U) .* db2amp(spl(tx))                 # (nr, nz)
     xrev ? reverse(fld; dims=1) : fld
 end
@@ -186,7 +192,7 @@ function UnderwaterAcoustics.acoustic_field(pm::BellhopJL,
     runmode = _runmode(mode)
     p = location(rx)
     env2d, zs, beam = _make_env2d(pm, tx, p.x)
-    U = pressure_field(env2d, zs, [p.x], [-p.z], beam, runmode)
+    U = pressure_field(env2d, zs, [p.x], [-p.z], beam, runmode; ntasks=pm.threads)
     -U[1, 1] * db2amp(spl(tx))
 end
 
@@ -199,12 +205,17 @@ function UnderwaterAcoustics.arrivals(pm::BellhopJL,
         (nbeams = round(Int, (pm.max_angle - pm.min_angle) / deg2rad(0.05)) + 1)
     env2d, zs, beam = _make_env2d(pm, tx, p.x; nbeams)
     f = env2d.freq
-    arr = compute_arrivals(env2d, zs, [p.x], [-p.z], beam)[1, 1]
+    arr = compute_arrivals(env2d, zs, [p.x], [-p.z], beam; ntasks=pm.threads)[1, 1]
+    # merged arrivals often share a take-off angle; trace each eigenray once
+    T = fieldtype(eltype(arr), :amp)
+    paths_by_angle = Dict{T,Vector{@NamedTuple{x::T, y::T, z::T}}}()
     out = map(arr) do a
         ϕ = a.amp * cis(a.phase) * exp(2π * f * imag(a.delay))
         path = if paths
-            ray = trace_ray(env2d, a.src_angle, zs, beam)
-            [(x=pt.x[1], y=zero(pt.x[1]), z=-pt.x[2]) for pt in ray]
+            get!(paths_by_angle, a.src_angle) do
+                ray = trace_ray(env2d, a.src_angle, zs, beam)
+                [(x=pt.x[1], y=zero(pt.x[1]), z=-pt.x[2]) for pt in ray]
+            end
         else
             missing
         end

--- a/src/bellhopjl/field.jl
+++ b/src/bellhopjl/field.jl
@@ -24,26 +24,60 @@ end
 "Semi-coherent source amplitude (Lloyd mirror), BellhopCore ('S' runs)."
 semicoherent_amp0(ω, c, zs, α) = sqrt(2) * abs(sin(ω / c * zs * sin(α)))
 
+"Partition `1:n` into at most `k` contiguous, near-equal chunks."
+_chunks(n, k) = [(1 + div((j - 1) * n, k)):div(j * n, k) for j in 1:min(k, n)]
+
+"Preallocated ray-history buffer, reused across a beam loop."
+function _ray_buffer(::Type{T}) where {T}
+    hist = Vector{RayPt{T}}()
+    sizehint!(hist, 2000)
+    hist
+end
+
 """
-    pressure_field(env, zs, rxr, rxz, beam, mode) -> Matrix{Complex} (nz × nr)
+    pressure_field(env, zs, rxr, rxz, beam, mode; ntasks=1) -> Matrix{Complex} (nz × nr)
 
 Trace all beams and assemble the receiver-grid pressure, including the final
 `ScalePressure` step. `rxr` ascending ranges [m], `rxz` depths [m, +down].
+With `ntasks > 1` the beam fan is split into contiguous chunks traced on
+separate threads, each with its own accumulator; the per-chunk fields are
+summed in chunk order, so results are reproducible for a given `ntasks`.
 """
 function pressure_field(env::Env2D, zs, rxr, rxz, beam::BeamParams{TB},
-                        mode::RunMode) where {TB}
+                        mode::RunMode; ntasks::Int=1) where {TB}
     T = promote_type(env_eltype(env), typeof(float(zs)), TB)
     ω = 2π * env.freq
     αs, Δα = takeoff_angles(T, beam)
-    sink = PressureSink{T}(zeros(Complex{T}, length(rxz), length(rxr)), mode)
     e0, _ = evaluate(env.ssp, T(zs), one(T), 1)
-    for α in αs
+    trace1! = (sink, hist, α) -> begin
         amp0 = mode == SEMICOHERENT ? semicoherent_amp0(ω, e0.c, T(zs), α) : one(T)
-        ray = trace_ray(env, α, zs, beam; amp0)
+        ray = trace_ray!(hist, env, α, zs, beam; amp0)
         influence_geo_cart!(sink, ray, α, Δα, ω, env.freq, rxr, rxz;
                             gaussian=beam.gaussian)
     end
-    scale_pressure!(sink.U, mode, rxr)
+    U = zeros(Complex{T}, length(rxz), length(rxr))
+    if ntasks <= 1 || length(αs) < 2 * ntasks
+        sink = PressureSink{T}(U, mode)
+        hist = _ray_buffer(T)
+        for α in αs
+            trace1!(sink, hist, α)
+        end
+    else
+        tasks = map(_chunks(length(αs), ntasks)) do idxs
+            Threads.@spawn begin
+                local csink = PressureSink{T}(zeros(Complex{T}, length(rxz), length(rxr)), mode)
+                local chist = _ray_buffer(T)
+                for i in idxs
+                    trace1!(csink, chist, αs[i])
+                end
+                csink.U
+            end
+        end
+        for t in tasks              # fixed order ⇒ deterministic reduction
+            U .+= fetch(t)
+        end
+    end
+    scale_pressure!(U, mode, rxr)
 end
 
 """
@@ -63,22 +97,51 @@ function scale_pressure!(U::Matrix{Complex{T}}, mode::RunMode, rxr) where {T}
 end
 
 """
-    compute_arrivals(env, zs, rxr, rxz, beam) -> Matrix{Vector{Arrival}}
+    compute_arrivals(env, zs, rxr, rxz, beam; ntasks=1) -> Matrix{Vector{Arrival}}
 
 Arrivals at each receiver. Cylindrical-spreading factor 1/√r is applied to
-amplitudes, as in `WriteArrivalsASCII` (ArrMod.f90).
+amplitudes, as in `WriteArrivalsASCII` (ArrMod.f90). With `ntasks > 1` the
+beam fan is split into contiguous chunks traced on separate threads, each
+with its own sink; the per-chunk arrival lists are then replayed through
+`add_arr!` in chunk (= beam) order, preserving the serial merge semantics.
 """
 function compute_arrivals(env::Env2D, zs, rxr, rxz,
-                          beam::BeamParams{TB}) where {TB}
+                          beam::BeamParams{TB}; ntasks::Int=1) where {TB}
     T = promote_type(env_eltype(env), typeof(float(zs)), TB)
     ω = 2π * env.freq
     αs, Δα = takeoff_angles(T, beam)
     arr = [Arrival{T}[] for _ in eachindex(rxz), _ in eachindex(rxr)]
-    sink = ArrivalSink{T}(arr)
-    for α in αs
-        ray = trace_ray(env, α, zs, beam)
-        influence_geo_cart!(sink, ray, α, Δα, ω, env.freq, rxr, rxz;
-                            gaussian=beam.gaussian)
+    if ntasks <= 1 || length(αs) < 2 * ntasks
+        sink = ArrivalSink{T}(arr)
+        hist = _ray_buffer(T)
+        for α in αs
+            ray = trace_ray!(hist, env, α, zs, beam)
+            influence_geo_cart!(sink, ray, α, Δα, ω, env.freq, rxr, rxz;
+                                gaussian=beam.gaussian)
+        end
+    else
+        tasks = map(_chunks(length(αs), ntasks)) do idxs
+            Threads.@spawn begin
+                local csink = ArrivalSink{T}([Arrival{T}[] for _ in eachindex(rxz),
+                                                               _ in eachindex(rxr)])
+                local chist = _ray_buffer(T)
+                for i in idxs
+                    local ray = trace_ray!(chist, env, αs[i], zs, beam)
+                    influence_geo_cart!(csink, ray, αs[i], Δα, ω, env.freq,
+                                        rxr, rxz; gaussian=beam.gaussian)
+                end
+                csink.arr
+            end
+        end
+        for t in tasks              # replay in beam order (serial merge semantics)
+            carr = fetch(t)
+            for k in eachindex(arr)
+                for a in carr[k]
+                    add_arr!(arr[k], ω, a.amp, a.phase, a.delay, a.src_angle,
+                             a.rcv_angle, a.ntop, a.nbot)
+                end
+            end
+        end
     end
     for ir in eachindex(rxr), iz in eachindex(rxz)
         r = rxr[ir]

--- a/src/bellhopjl/influence.jl
+++ b/src/bellhopjl/influence.jl
@@ -119,7 +119,7 @@ function influence_geo_cart!(sink::InfluenceSink, ray::Vector{RayPt{T}}, α, Δ�
     BeamWindow = 4      # Gaussian beam window: kills beams outside e^(-0.5 w²)
     srcang = T(α)
 
-    for is in 2:nsteps
+    @inbounds for is in 2:nsteps
         rB = ray[is].x[1]
         x_ray = ray[is-1].x
 

--- a/src/bellhopjl/ssp.jl
+++ b/src/bellhopjl/ssp.jl
@@ -36,7 +36,7 @@ Depth-segment update with the tangent-direction-aware edge-case handling of
 """
 @inline function update_seg(z::AbstractVector, zq, tz, iseg::Int)
     n = length(z)
-    if tz >= 0
+    @inbounds if tz >= 0
         while zq < z[iseg] && iseg > 1
             iseg -= 1
         end

--- a/src/bellhopjl/trace.jl
+++ b/src/bellhopjl/trace.jl
@@ -65,6 +65,20 @@ Fortran.
 function trace_ray(env::Env2D, α, zs, beam::BeamParams; amp0=1)
     T = promote_type(env_eltype(env), typeof(float(α)), typeof(float(zs)),
                      typeof(beam.deltas), typeof(float(amp0)))
+    hist = Vector{RayPt{T}}()
+    sizehint!(hist, 2000)
+    trace_ray!(hist, env, α, zs, beam; amp0)
+end
+
+"""
+    trace_ray!(hist, env, α, zs, beam; amp0=1) -> hist
+
+In-place variant of [`trace_ray`](@ref): empties `hist` and fills it with the
+traced ray, so one buffer can be reused across the beam loop.
+"""
+function trace_ray!(hist::Vector{RayPt{T}}, env::Env2D, α, zs,
+                    beam::BeamParams; amp0=1) where {T}
+    empty!(hist)
     ω = 2π * env.freq
     deltas = T(beam.deltas)
     box = (r = T(beam.box_r), z = T(beam.box_z))
@@ -79,8 +93,6 @@ function trace_ray(env::Env2D, α, zs, beam::BeamParams; amp0=1)
     # q initialised to (0,0): TraceRay2D sets q = 0 for geometric beam runs
     # ('G'); the (p₂,q₂) plane-wave pair is decoupled from (p₁,q₁) and unused
     # by the geometric influence functions, so this also matches 'B' runs.
-    hist = Vector{RayPt{T}}()
-    sizehint!(hist, 2000)
     push!(hist, ray)
 
     iTop = get_seg(env.top, xs[1], ray.t[1])

--- a/test/test_bellhopjl.jl
+++ b/test/test_bellhopjl.jl
@@ -160,3 +160,30 @@ end
   tl2c = transmission_loss(Bellhop(env), tx, rxs)
   @test median(abs.(tl1c .- tl2c)) < 0.1
 end
+
+@testitem "bellhopjl-threads" begin
+  using UnderwaterAcoustics
+  # serial vs threaded results must agree (bitwise-reproducible per thread
+  # count; serial vs threaded differ only by floating-point reassociation)
+  env = UnderwaterEnvironment(bathymetry = 100.0, soundspeed = 1500.0,
+    seabed = FluidBoundary(1900.0, 1650.0, 0.0))
+  tx = AcousticSource(0.0, -25.0, 500.0)
+  rxs = AcousticReceiverGrid2D(range(200.0, 5000.0; length=120),
+                               range(-95.0, -5.0; length=45))
+  pm1 = BellhopJL(env; threads=1)
+  pm4 = BellhopJL(env; threads=4)
+  @test_throws ErrorException BellhopJL(env; threads=0)
+  x1 = acoustic_field(pm1, tx, rxs)
+  x4 = acoustic_field(pm4, tx, rxs)
+  @test x4 == acoustic_field(pm4, tx, rxs)       # deterministic
+  @test isapprox(x1, x4; rtol=1e-10, nans=true)
+  y1 = acoustic_field(pm1, tx, rxs; mode=:incoherent)
+  y4 = acoustic_field(pm4, tx, rxs; mode=:incoherent)
+  @test isapprox(y1, y4; rtol=1e-10, nans=true)
+  rx = AcousticReceiver(1000.0, -60.0)
+  a1 = arrivals(pm1, tx, rx)
+  a4 = arrivals(pm4, tx, rx)
+  @test length(a1) == length(a4)
+  @test all(isapprox(a1[j].t, a4[j].t; atol=1e-12) for j in eachindex(a1))
+  @test all(isapprox(a1[j].ϕ, a4[j].ϕ; rtol=1e-8) for j in eachindex(a1))
+end


### PR DESCRIPTION
## Summary

Speeds up `BellhopJL` without changing external behavior (all existing golden/analytic/AD tests pass unchanged):

- **Ray-buffer reuse** — new `trace_ray!` empties and refills one preallocated buffer per beam loop instead of allocating a fresh `Vector{RayPt}` per beam (2.15 GiB → 6.5 MiB allocated on the Pekeris TL grid).
- **Multithreaded beam loop** — `BellhopJL` gains a `threads` kwarg (default `Threads.nthreads()`; `threads=1` runs the identical serial path). The beam fan is split into contiguous chunks, each with its own accumulator; per-chunk fields are summed in fixed chunk order (deterministic for a given thread count) and per-chunk arrival lists are replayed through `add_arr!` in beam order to preserve the Fortran merge semantics.
- **Eigenray retrace memoization** — `arrivals` traces each unique take-off angle once when extracting ray paths.
- **`@inbounds`** on the influence receiver loop and SSP segment scan (validated with a full `--check-bounds=yes` test run). No `@simd`/`@fastmath` anywhere — the step math stays numerically faithful to the Fortran.
- New `bellhopjl-threads` testitem (determinism + serial-vs-threaded agreement) and PORTING_NOTES.md entries for each deviation.

## Benchmarks (Apple Silicon, Julia 1.12.6)

| Benchmark | before (1t) | after (1t) | after (8t) | total |
|---|---|---|---|---|
| Pekeris coherent TL grid | 781 ms | 517 ms | 217 ms | 3.6× |
| Pekeris incoherent TL grid | 670 ms | 411 ms | 165 ms | 4.1× |
| Arrivals (no paths) | 126 ms | 94 ms | 33 ms | 3.8× |
| Arrivals (with paths) | 132 ms | 101 ms | 39 ms | 3.4× |
| Munk Gaussian TL, 100 km | 114 ms | 108 ms | 21 ms | 5.4× |
| ForwardDiff 6-var gradient | 1.72 s | 0.93 s | 0.33 s | 5.1× |

## Test plan

- [x] Full suite at `-t 4` (535 pass, incl. new `bellhopjl-threads` testitem)
- [x] Full suite single-threaded with `--check-bounds=yes`
- [x] ForwardDiff gradient test under threads