### PR TITLE
Native Julia port of Kraken / KrakenC with `ForwardDiff` support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "AcousticsToolbox"
 uuid = "268a15bc-5756-47d6-9bea-fa5dc21c97f8"
-authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
 version = "0.7.0"
+authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
 
 [deps]
 AcousticsToolbox_jll = "6380ca6f-c335-511c-b45e-8a1ed8902ca7"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -12,6 +13,7 @@ UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
 AcousticsToolbox_jll = "2025.9.6"
+ForwardDiff = "0.10, 1"
 LinearAlgebra = "1"
 Printf = "1"
 StaticArrays = "1"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Currently, the following models are supported:
   (no file I/O, ForwardDiff-differentiable; see
   [src/bellhopjl/PORTING_NOTES.md](src/bellhopjl/PORTING_NOTES.md) for the
   port's provenance and deviations from the Fortran)
+- KrakenJL — a native Julia port of the Kraken/KrakenC 2D normal mode models
+  (no file I/O, multithreaded; see
+  [src/krakenjl/PORTING_NOTES.md](src/krakenjl/PORTING_NOTES.md) for the
+  port's provenance and deviations from the Fortran)
 
 For information on how to use the models, see [documentation](https://org-arl.github.io/UnderwaterAcoustics.jl/).
 
@@ -25,22 +29,30 @@ For information on how to use the models, see [documentation](https://org-arl.gi
 
 This package is dual-licensed on a per-directory basis:
 
-- Everything **except** `src/bellhopjl/` is licensed under the [MIT license](LICENSE).
+- Everything **except** `src/bellhopjl/` and `src/krakenjl/` is licensed under
+  the [MIT license](LICENSE).
 - `src/bellhopjl/` (the `BellhopJL` solver) is a native Julia port of Bellhop — a
   derivative work of the GPL-licensed Bellhop (© 1983–2022 Michael B. Porter;
   [A-New-BellHope](https://github.com/A-New-BellHope/bellhop) changes © 2021–2023
   The Regents of the University of California) — and is licensed under
-  [GPL-3.0-or-later](LICENSE-GPL-3.0). Each file in that directory carries an
-  `SPDX-License-Identifier: GPL-3.0-or-later` header. The port's lineage and
-  every intentional deviation from the Fortran are documented in
-  [src/bellhopjl/PORTING_NOTES.md](src/bellhopjl/PORTING_NOTES.md).
+  [GPL-3.0-or-later](LICENSE-GPL-3.0).
+- `src/krakenjl/` (the `KrakenJL` solver) is a native Julia port of
+  Kraken/KrakenC — a derivative work of the GPL-licensed KRAKEN (© Michael B.
+  Porter, OALIB Acoustics Toolbox 2024_12_25) — and is likewise licensed under
+  [GPL-3.0-or-later](LICENSE-GPL-3.0).
+
+Each file in those directories carries an `SPDX-License-Identifier:
+GPL-3.0-or-later` header. The ports' lineage and every intentional deviation
+from the Fortran are documented in
+[src/bellhopjl/PORTING_NOTES.md](src/bellhopjl/PORTING_NOTES.md) and
+[src/krakenjl/PORTING_NOTES.md](src/krakenjl/PORTING_NOTES.md).
 
 Note that this package already downloads and executes the GPL-licensed OALIB
 Fortran binaries (via `AcousticsToolbox_jll`) for the `Bellhop`/`Kraken` models, so
-GPL software is involved either way; with the `BellhopJL` component included in the
-source tree, **distribution of the combined package is subject to the terms of the
-GPL-3.0**. If you need MIT-only terms, strip `src/bellhopjl/` (the rest of the
-package does not depend on it).
+GPL software is involved either way; with the `BellhopJL` and `KrakenJL` components
+included in the source tree, **distribution of the combined package is subject to
+the terms of the GPL-3.0**. If you need MIT-only terms, strip `src/bellhopjl/` and
+`src/krakenjl/` (the rest of the package does not depend on them).
 
 ## Contributing
 
@@ -50,4 +62,5 @@ The scopes active in this repository are:
 - **bellhop**: Bellhop
 - **bellhopjl**: BellhopJL
 - **kraken**: Kraken
+- **krakenjl**: KrakenJL
 - **orca**: Orca

--- a/src/AcousticsToolbox.jl
+++ b/src/AcousticsToolbox.jl
@@ -21,4 +21,11 @@ include("bellhopjl/BellhopJLCore.jl")
 using .BellhopJLCore: BellhopJL
 export BellhopJL
 
+# KrakenJL (native Julia port of Kraken/KrakenC) lives in an internal
+# submodule; like src/bellhopjl/**, src/krakenjl/** is GPL-3.0-or-later
+# (see LICENSE-GPL-3.0), unlike the rest of this package (MIT)
+include("krakenjl/KrakenJLCore.jl")
+using .KrakenJLCore: KrakenJL
+export KrakenJL
+
 end # module

--- a/src/krakenjl/KrakenJLCore.jl
+++ b/src/krakenjl/KrakenJLCore.jl
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# KrakenJLCore — native Julia port of the KRAKEN / KRAKENC normal-mode models
+# (derivative work of KRAKEN by Michael B. Porter, from the OALIB Acoustics
+# Toolbox release 2024_12_25). Unlike the rest of AcousticsToolbox.jl (MIT),
+# everything under src/krakenjl/ is licensed GPL-3.0-or-later — see
+# LICENSE-GPL-3.0 at the repository root.
+#
+# This internal submodule keeps the port's helpers out of the parent
+# namespace; the public model type `KrakenJL` is re-exported by
+# AcousticsToolbox. Comments cite the originating Fortran file/subroutine
+# throughout so the code remains diffable against upstream. See
+# PORTING_NOTES.md in this directory for lineage and deviations.
+
+module KrakenJLCore
+
+using LinearAlgebra
+
+include("attenuation.jl")
+include("types.jl")
+include("mesh.jl")
+include("bcimp.jl")
+include("solve.jl")
+include("modes.jl")
+include("field.jl")
+include("api.jl")
+
+export KrakenJL
+
+end # module

--- a/src/krakenjl/KrakenJLCore.jl
+++ b/src/krakenjl/KrakenJLCore.jl
@@ -18,6 +18,7 @@ using LinearAlgebra
 
 include("attenuation.jl")
 include("types.jl")
+include("dual.jl")
 include("mesh.jl")
 include("bcimp.jl")
 include("solve.jl")

--- a/src/krakenjl/PORTING_NOTES.md
+++ b/src/krakenjl/PORTING_NOTES.md
@@ -1,0 +1,111 @@
+# KrakenJL porting notes — provenance and deviations
+
+This directory contains a native Julia port of the KRAKEN and KRAKENC normal
+mode models. This file documents the port's lineage, every intentional
+deviation from the Fortran sources, and the provenance of the validation
+data. (Everything in `src/krakenjl/` is GPL-3.0-or-later — see
+`LICENSE-GPL-3.0` at the repository root; the rest of AcousticsToolbox.jl is
+MIT.)
+
+## 1. Lineage
+
+Ported from the **OALIB Acoustics Toolbox release 2024_12_25**
+(`http://oalib.hlsresearch.com/AcousticsToolbox/at_2024_12_25.zip`, sha256
+`7b57e80bded7f71ea9536e541029615f3f430e390651d697a2212569cbafd85c`) — the
+exact source tree the `AcousticsToolbox_jll` 2025.9.6 binaries are compiled
+from (per the Yggdrasil build recipe), so the port and the wrapped Fortran
+`Kraken` model share their algorithm version. KRAKEN © Michael B. Porter,
+GPL-3.0.
+
+Files ported (docstrings cite the originating subroutine throughout):
+
+| Julia file | Fortran source |
+|---|---|
+| `types.jl` | `KrakenMod.f90`, `KrakencMod.f90` (module variables → structs) |
+| `attenuation.jl` | `misc/AttenMod.f90` (CRCI, Franc_Garr) |
+| `mesh.jl` | `Initialize` (kraken(c).f90), `cLinear`/`cCubic` (misc/sspMod.f90), `CSPLINE` (misc/splinec.f90), auto-mesh rule of `ReadEnvironmentMod.f90` |
+| `bcimp.jl` | `BCImpedanceMod.f90`, `BCImpedancecMod.f90`, `misc/PekRoot.f90` |
+| `solve.jl` | `FUNCT`/`AcousticLayers`/`Solve`/`Solve1`/`Solve2`/`Bisection` (kraken(c).f90), `RootFinderBrent.f90`, `misc/RootFinderSecantMod.f90` |
+| `modes.jl` | `Vector`/`Normalize`/`ScatterLoss` (kraken(c).f90), `InverseIterationMod.f90`, `KupIng` (Kraken/Scattering.f90) |
+| `field.jl` | `Evaluate` (KrakenField/EvaluateMod.f90), `Weight` (misc/calculateweights.f90) |
+| `api.jl` | behavioral port of the wrapper `src/kraken.jl` + `src/common.jl _write_env` |
+
+The ORCA sources were **not** consulted (restrictive ARL:UT license).
+
+## 2. Scope
+
+Only the features reachable through the UnderwaterAcoustics.jl API of the
+Fortran wrapper are implemented: one profile (range-independent), one
+frequency, point source, cylindrical coordinates, coherent/incoherent mode
+summation ('R… C/I' field options), fluid/elastic/multilayer-elastic
+seabeds, vacuum/rigid/acousto-elastic surface, C-linear and cubic-spline
+SSPs, 'WF' attenuation (dB/λ + Francois-Garrison volume attenuation). Not
+ported: tabulated/precalculated reflection coefficients ('F'/'P' BCs),
+broadband mode files, profile continuation (`Solve3`), BOUNCE, field3d,
+coupled modes, twersky scatter, biological attenuation.
+
+## 3. Intentional deviations from the Fortran
+
+- **No env/mod/shd/flp file I/O** — environments come directly from
+  UnderwaterAcoustics.jl; the adapter (`api.jl`) mirrors the unit conversions
+  of this package's Fortran env-file writer verbatim (density ratio in g/cm³,
+  attenuation in dB/λ, Francois-Garrison volume attenuation with
+  z̄ = waterdepth/2 applied through CRCI to every medium and halfspace, mesh
+  count `round(waterdepth/λ·mesh_density)` with the ReadEnvironmentMod
+  auto rule when 0, `rmax = Inf → 1.01·max receiver range`, converted to km
+  for the Richardson convergence test).
+- **Precision** — double precision throughout. The Fortran writes mode
+  shapes, eigenvalues and the pressure field in single precision (`.mod` /
+  `.shd` records are `COMPLEX*4`) and the field program sums modes in single
+  precision; this port keeps `Float64`, so results differ from the wrapped
+  binaries at the ~1e-7 relative level.
+- **Mode shapes on the solver mesh** — `arrivals` returns ψ sampled on the
+  solver's own finite-difference mesh instead of the wrapper's λ/10
+  resampling (finer; no information loss). Field evaluation tabulates ψ at
+  source/receiver depths by the same linear interpolation as `Weight`.
+- **Group speed alignment** — the wrapper scrapes group speeds from the .prt
+  file and re-interpolates them against kᵣ; this port keeps the per-mode
+  values directly (equivalent). As in the Fortran, the real-path KRAKEN
+  leaves VG unset (its assignment is commented out upstream), so
+  `complex_solver=false` reports zeros.
+- **Deterministic restarts** — KRAKENC's random restart of the secant search
+  (`RANDOM_NUMBER`) is replaced by a deterministic xorshift generator seeded
+  per solve, so results are reproducible run-to-run.
+- **Multithreading** — inverse iteration (independent per mode) and field
+  summation (independent per range column) are optionally chunked across
+  threads (`threads` kwarg, default `Threads.nthreads()`). Each mode/column
+  is written by exactly one task, so threaded results are bit-identical to
+  serial.
+- **Density subtabulation** — rho is interpolated rho-linearly in both the
+  C-linear and spline SSP paths (the Fortran splines rho in `cCubic`; the
+  wrapper only ever writes piecewise-constant rho per medium, for which both
+  are exact).
+- `attenuation.jl` is a duplicate of `src/bellhopjl/attenuation.jl` (both
+  port misc/AttenMod.f90); duplicated to keep each GPL submodule
+  self-contained.
+- **No modefile-based initial guesses** ('I' option) and no `Solve3` profile
+  continuation — single-profile scope.
+- **Errors instead of dummy mode files** — "No modes for given phase speed
+  interval" raises a Julia error (the Fortran writes a dummy MODFile for
+  FIELD3D and calls ERROUT).
+- **ForwardDiff** — not supported in this initial port (the eigenvalue
+  search is not dual-safe); use the fallback `FiniteDifferences` route if
+  gradients are needed.
+
+## 4. Validation provenance
+
+- `test/test_krakenjl.jl` cross-checks against
+  `UnderwaterAcoustics.PekerisModeSolver` (mode count, kᵣ to 1e-3, mean TL
+  < 1 dB) on the Pekeris scenario of `test_kraken.jl`, and at runtime against
+  the Fortran `Kraken` wrapper (multilayer elastic seabed and Munk spline
+  SSP: median |ΔTL| < 0.1 dB, coherent and incoherent).
+- **Golden references** (hardcoded constants in `test_krakenjl.jl`) were
+  generated from the Fortran Kraken/KrakenC (`AcousticsToolbox_jll`
+  2025.9.6 = OALIB 2024_12_25) on 2026-07-13: Pekeris kᵣ (real to 1e-7,
+  imag to 1%) and TL (0.1 dB); lossy elastic seabed kᵣ and TL likewise.
+- Observed agreement with the Fortran on the scenarios above: mean |ΔTL|
+  ≈ 0.003 dB (Pekeris), ≈ 0.0004 dB (elastic), ≈ 0.002 dB (Munk spline) —
+  residuals dominated by the Fortran's single-precision file records.
+- The real-solver (`complex_solver=false`) elastic-seabed case fails with
+  "No modes for given phase speed interval" exactly as the Fortran KRAKEN
+  does (it caps cHigh at the halfspace shear speed).

--- a/src/krakenjl/PORTING_NOTES.md
+++ b/src/krakenjl/PORTING_NOTES.md
@@ -88,9 +88,18 @@ coupled modes, twersky scatter, biological attenuation.
 - **Errors instead of dummy mode files** — "No modes for given phase speed
   interval" raises a Julia error (the Fortran writes a dummy MODFile for
   FIELD3D and calls ERROUT).
-- **ForwardDiff** — not supported in this initial port (the eigenvalue
-  search is not dual-safe); use the fallback `FiniteDifferences` route if
-  gradients are needed.
+- **ForwardDiff support via implicit-function correction** (`dual.jl`) —
+  the eigenvalue search (secant/Brent/bisection with deflation and restarts)
+  runs on ForwardDiff *values* only; each converged eigenvalue is then made
+  dual-exact with a single Newton step of the undeflated characteristic
+  function in dual arithmetic (∂Δ/∂x by the same central-difference device
+  `Normalize` uses for admittance derivatives). Richardson extrapolation,
+  inverse iteration, normalization, perturbations and the mode summation are
+  re-run in dual arithmetic. Discrete quantities (mode count, mesh counts,
+  turning-point index) are frozen at their value-space results; gradients are
+  one-sided at model kinks (receiver depth exactly on a mesh node, integer
+  water depth toggling the extra-SSP-node branch). Verified against central
+  differences to ~1e-5 relative at generic parameter values.
 
 ## 4. Validation provenance
 

--- a/src/krakenjl/api.jl
+++ b/src/krakenjl/api.jl
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# UnderwaterAcoustics.jl integration. This is the only file that touches
+# UnderwaterAcoustics.jl types; it mirrors the environment handling (and unit
+# conversions) of the Fortran Kraken wrapper (src/kraken.jl and
+# src/common.jl _write_env) so that KrakenJL is a drop-in alternative.
+
+using UnderwaterAcoustics
+using UnderwaterAcoustics: AbstractModePropagationModel, AbstractAcousticSource,
+                           AbstractAcousticReceiver, AcousticReceiverGrid2D,
+                           ModeArrival, SampledFieldZ, SampledFieldXZ,
+                           RigidBoundary, PressureReleaseBoundary, FluidBoundary,
+                           ElasticBoundary, MultilayerElasticBoundary,
+                           is_range_dependent, is_constant, value, in_units,
+                           db2amp, in_dBperλ, CubicSpline
+
+"""
+    KrakenJL(env; kwargs...)
+
+Native-Julia port of the KRAKEN / KRAKENC normal-mode models — a drop-in
+alternative to the Fortran-wrapping `Kraken` model in this package.
+
+Supported keyword arguments:
+- `nmodes`: number of modes to use (default: 9999)
+- `mesh_density`: number of mesh points per wavelength (default: 0, 0=auto)
+- `clow`: lower limit of phase speed (default: 1300, 0=auto)
+- `chigh`: upper limit of phase speed (default: 2500)
+- `rmax`: largest range (in m) of interest (default: Inf, meaning 1% more
+  than the furthest receiver)
+- `complex_solver`: use the KRAKENC complex solver (default: true)
+- `robust`: use robust (but slow) root finder restarts (default: false)
+- `threads`: number of threads for mode/field computation
+  (default: `Threads.nthreads()`; 1 runs the serial code path)
+"""
+struct KrakenJL{T} <: AbstractModePropagationModel
+    env::T
+    nmodes::Int
+    mesh_density::Float64
+    clow::Float64
+    chigh::Float64
+    rmax::Float64
+    complex_solver::Bool
+    robust::Bool
+    threads::Int
+    function KrakenJL(env, nmodes, mesh_density, clow, chigh, rmax,
+                      complex_solver, robust, threads)
+        _check_krakenjl_env(env)
+        nmodes ≥ 1 || error("number of modes should be positive")
+        mesh_density ≥ 0 || error("mesh density should be non-negative")
+        clow ≥ 0 || error("clow should be non-negative")
+        chigh > clow || error("chigh should be more than clow")
+        rmax ≥ 0 || error("rmax should be non-negative")
+        threads ≥ 1 || error("threads should be at least 1")
+        new{typeof(env)}(env, nmodes, Float64(mesh_density), Float64(clow),
+                         Float64(chigh), Float64(rmax), complex_solver, robust,
+                         threads)
+    end
+end
+
+KrakenJL(env; nmodes=9999, mesh_density=0, clow=1300.0, chigh=2500.0, rmax=Inf,
+         complex_solver=true, robust=false, threads=Threads.nthreads()) =
+    KrakenJL(env, nmodes, mesh_density, clow, chigh, rmax, complex_solver,
+             robust, threads)
+
+Base.show(io::IO, pm::KrakenJL) = print(io, "KrakenJL(⋯)")
+
+### adapter helpers
+
+# mirrors _check_env(::Type{Kraken}, env) in src/kraken.jl
+function _check_krakenjl_env(env)
+    env.seabed isa FluidBoundary || env.seabed isa ElasticBoundary ||
+        env.seabed isa MultilayerElasticBoundary ||
+        error("seabed must be a FluidBoundary, ElasticBoundary or MultilayerElasticBoundary")
+    env.surface isa FluidBoundary || error("surface must be a FluidBoundary")
+    is_range_dependent(env.soundspeed) && error("Range-dependent soundspeed not supported")
+    is_range_dependent(env.altimetry) && error("Range-dependent altimetry not supported")
+    is_range_dependent(env.bathymetry) && error("Range-dependent bathymetry not supported")
+    nothing
+end
+
+# nominal half-wavelength sampling (mirrors _recommend_len, src/common.jl)
+function _kj_recommend_len(x, f)
+    λ = 1500.0 / f
+    clamp(round(Int, 2x / λ) + 1, 25, 1000)
+end
+
+# UA boundary → Halfspace. Unit conversions mirror _write_env (src/common.jl):
+# density ratio ρ/1000 (g/cm³), attenuation in dB/λ, Francois-Garrison volume
+# attenuation applied through crci as the Fortran CRCI does for AttenUnit 'WF'
+function _kj_halfspace(b, f, fg)
+    T = Float64
+    if b === RigidBoundary
+        Halfspace{T}(:rigid)
+    elseif b === PressureReleaseBoundary
+        Halfspace{T}(:vacuum)
+    elseif b isa ElasticBoundary
+        if b.cₛ == 0    # cₛ = 0 elastic reduces to fluid (mirrors _write_env)
+            Halfspace{T}(:acoustoelastic,
+                         crci(float(b.cₚ), in_dBperλ(b.δₚ), f; volume=fg),
+                         zero(Complex{T}), b.ρ / 1000)
+        else
+            Halfspace{T}(:acoustoelastic,
+                         crci(float(b.cₚ), in_dBperλ(b.δₚ), f; volume=fg),
+                         crci(float(b.cₛ), in_dBperλ(b.δₛ), f; volume=fg),
+                         b.ρ / 1000)
+        end
+    else                # FluidBoundary
+        Halfspace{T}(:acoustoelastic,
+                     crci(float(b.c), in_dBperλ(b.δ), f; volume=fg),
+                     zero(Complex{T}), b.ρ / 1000)
+    end
+end
+
+"""
+Build the internal `Problem` (+ base mesh counts) from a UA environment,
+source and receiver extent. Mirrors the Kraken blocks of `_write_env`
+(src/common.jl) and the auto-mesh rule of ReadEnvironmentMod.f90.
+"""
+function _make_problem(pm::KrakenJL, tx, maxr)
+    T = Float64
+    env = pm.env
+    f = float(frequency(tx))
+    ssp = env.soundspeed
+    waterdepth = float(maximum(env.bathymetry))
+    fg = FrancoisGarrison(float(env.temperature), float(env.salinity),
+                          float(env.pH), float(waterdepth / 2))
+
+    media = Medium{T}[]
+    sigma = T[float(env.surface.σ)]
+
+    # water column (SSP block of _write_env; water density ratio = 1, water
+    # attenuation = volume attenuation only)
+    spline = ssp isa SampledFieldZ && ssp.interp === CubicSpline()
+    zn = T[]
+    cn = Complex{T}[]
+    if is_constant(ssp)
+        c = float(value(ssp))
+        zn = [0.0, waterdepth]
+        cn = [crci(c, 0.0, f; volume=fg) for _ in 1:2]
+    elseif ssp isa SampledFieldZ
+        zrange = sort!(vcat(collect(ssp.zrange), -waterdepth); rev=true)
+        for z in zrange
+            push!(zn, -z)
+            push!(cn, crci(float(ssp(z)), 0.0, f; volume=fg))
+            z == -waterdepth && break
+        end
+    else
+        for d in range(0.0, waterdepth; length=_kj_recommend_len(waterdepth, f))
+            push!(zn, d)
+            push!(cn, crci(float(ssp(-d)), 0.0, f; volume=fg))
+        end
+        if floor(waterdepth) != waterdepth
+            push!(zn, waterdepth)
+            push!(cn, crci(float(ssp(-waterdepth)), 0.0, f; volume=fg))
+        end
+    end
+    λ = maximum(ssp) / f
+    ng_water = round(Int, waterdepth / λ * pm.mesh_density)
+    push!(media, Medium{T}(0.0, waterdepth, zn, cn, zeros(Complex{T}, length(zn)),
+                           ones(T, length(zn)), spline, ng_water))
+
+    # sediment layers of a multilayer elastic seabed (mirrors _write_env)
+    depth = waterdepth
+    seabed = env.seabed
+    if seabed isa MultilayerElasticBoundary
+        for l in seabed.layers[1:end-1]
+            ρ₁, ρ₂ = float(first(l.ρ)), float(last(l.ρ))
+            cₚ₁, cₚ₂ = float(first(l.cₚ)), float(last(l.cₚ))
+            cₛ₁, cₛ₂ = float(first(l.cₛ)), float(last(l.cₛ))
+            λₗ = max(cₚ₁, cₛ₁, cₚ₂, cₛ₂) / f
+            # Kraken manual recommends double mesh density for elastic media
+            ngl = round(Int, 2 * l.h / λₗ * pm.mesh_density)
+            push!(media, Medium{T}(depth, depth + l.h,
+                [depth, depth + l.h],
+                [crci(cₚ₁, in_dBperλ(l.δₚ), f; volume=fg),
+                 crci(cₚ₂, in_dBperλ(l.δₚ), f; volume=fg)],
+                [crci(cₛ₁, in_dBperλ(l.δₛ), f; volume=fg),
+                 crci(cₛ₂, in_dBperλ(l.δₛ), f; volume=fg)],
+                [ρ₁ / 1000, ρ₂ / 1000], false, ngl))
+            push!(sigma, float(l.σ))
+            depth += l.h
+        end
+        l = seabed.layers[end]
+        seabed = ElasticBoundary(l.ρ, l.cₚ, l.cₛ, l.δₚ, l.δₛ)
+    end
+
+    hstop = _kj_halfspace(env.surface, f, fg)
+    hsbot = _kj_halfspace(seabed, f, fg)
+    push!(sigma, float(seabed === RigidBoundary || seabed === PressureReleaseBoundary ?
+                       0.0 : seabed.σ))
+
+    rmax = isinf(pm.rmax) ? 1.01 * maxr : pm.rmax
+    prob = Problem{T}(f, media, sigma, hstop, hsbot, pm.clow, pm.chigh,
+                      rmax / 1000)      # rmax in km, as read from the env file
+
+    # base mesh counts (NG); 0 → auto rule of ReadEnvironmentMod.f90
+    ngs = [m.ng > 0 ? m.ng : auto_ng(m, f) for m in prob.media]
+    prob, ngs
+end
+
+_kj_solve(pm::KrakenJL, tx, maxr) = begin
+    prob, ngs = _make_problem(pm, tx, maxr)
+    solve_modes(prob, ngs; complex_solver=pm.complex_solver, robust=pm.robust,
+                threads=pm.threads)
+end
+
+### interface functions
+
+function UnderwaterAcoustics.arrivals(pm::KrakenJL, tx1::AbstractAcousticSource,
+                                      rx1::AbstractAcousticReceiver)
+    res = _kj_solve(pm, tx1, location(rx1).x)
+    ω = 2π * float(frequency(tx1))
+
+    # group-speed validity check mirrors src/kraken.jl arrivals: KRAKEN (real
+    # solver) leaves VG = 0 (reported as 0); invalid values → missing
+    max_c = maximum(pm.env.soundspeed)
+    if pm.env.seabed isa MultilayerElasticBoundary
+        max_c = 2 * max(max_c, maximum(l -> max(maximum(l.cₚ), maximum(l.cₛ)),
+                                       pm.env.seabed.layers[1:end-1]))
+    elseif pm.env.seabed isa ElasticBoundary
+        max_c = 2 * max(max_c, maximum(pm.env.seabed.cₚ), maximum(pm.env.seabed.cₛ))
+    else
+        max_c = 2 * max(max_c, maximum(pm.env.seabed.c))
+    end
+    v = all(vi -> 0 ≤ vi ≤ max_c, res.vg) ? Vector{Union{Missing,Float64}}(res.vg) :
+        Vector{Union{Missing,Float64}}(fill(missing, length(res.k)))
+
+    map(1:min(length(res.k), pm.nmodes)) do i
+        # mode shapes on the solver's own mesh (finer than the wrapper's λ/10
+        # resampling — see PORTING_NOTES §3)
+        ψ = SampledField(res.phi[:, i]; z=-res.z)
+        ModeArrival{ComplexF64,typeof(ψ),Union{Missing,Float64},Float64}(
+            i, res.k[i], ψ, v[i], ω / real(res.k[i]))
+    end
+end
+
+function UnderwaterAcoustics.acoustic_field(pm::KrakenJL,
+        tx1::AbstractAcousticSource, rx::AcousticReceiverGrid2D; mode=:coherent)
+    mode ∈ (:coherent, :incoherent) || error("Unknown mode :" * string(mode))
+    maxr = maximum(rx.xrange)
+    res = _kj_solve(pm, tx1, maxr)
+    M = min(length(res.k), pm.nmodes)
+
+    zrev = first(rx.zrange) < last(rx.zrange)   # ascending depths for eval
+    rxz = sort([-z for z in rx.zrange])
+    xrev = first(rx.xrange) > last(rx.xrange)
+    rxr = xrev ? reverse(collect(float.(rx.xrange))) : collect(float.(rx.xrange))
+
+    phiS = tabulate_modes(res, [-location(tx1).z])[1, 1:M]
+    phiR = tabulate_modes(res, rxz)[:, 1:M]
+    P = evaluate_field(res.k[1:M], phiS, phiR, rxr;
+                       incoherent=(mode === :incoherent), threads=pm.threads)
+
+    # match the wrapper output: SHD files negate the pressure (_read_shd) and
+    # Kraken uses the cis(-kᵣR) convention, hence the conjugation
+    fld = conj.(-permutedims(P) .* db2amp(spl(tx1)))    # (nr, nz)
+    xrev && (fld = reverse(fld; dims=1))
+    zrev && (fld = reverse(fld; dims=2))
+    fld
+end
+
+function UnderwaterAcoustics.acoustic_field(pm::KrakenJL,
+        tx1::AbstractAcousticSource, rx1::AbstractAcousticReceiver; mode=:coherent)
+    mode ∈ (:coherent, :incoherent) || error("Unknown mode :" * string(mode))
+    p = location(rx1)
+    res = _kj_solve(pm, tx1, p.x)
+    M = min(length(res.k), pm.nmodes)
+    phiS = tabulate_modes(res, [-location(tx1).z])[1, 1:M]
+    phiR = tabulate_modes(res, [-p.z])[:, 1:M]
+    P = evaluate_field(res.k[1:M], phiS, phiR, [float(p.x)];
+                       incoherent=(mode === :incoherent), threads=pm.threads)
+    conj(-P[1, 1] * db2amp(spl(tx1)))
+end

--- a/src/krakenjl/api.jl
+++ b/src/krakenjl/api.jl
@@ -78,6 +78,30 @@ function _check_krakenjl_env(env)
     nothing
 end
 
+# promoted scalar type for the solve, so ForwardDiff duals in the frequency,
+# soundspeed, bathymetry or boundary parameters flow through
+function _kj_eltype(env, f)
+    T = promote_type(typeof(float(f)), typeof(float(maximum(env.bathymetry))),
+                     typeof(float(maximum(env.soundspeed))), Float64)
+    for b in (env.surface, env.seabed)
+        if b isa FluidBoundary
+            T = promote_type(T, typeof(float(b.c)), typeof(float(b.ρ)),
+                             typeof(float(b.δ)))
+        elseif b isa ElasticBoundary
+            T = promote_type(T, typeof(float(b.cₚ)), typeof(float(b.cₛ)),
+                             typeof(float(b.ρ)), typeof(float(b.δₚ)),
+                             typeof(float(b.δₛ)))
+        elseif b isa MultilayerElasticBoundary
+            for l in b.layers
+                T = promote_type(T, typeof(float(first(l.cₚ))),
+                                 typeof(float(first(l.cₛ))),
+                                 typeof(float(first(l.ρ))), typeof(float(l.h)))
+            end
+        end
+    end
+    T
+end
+
 # nominal half-wavelength sampling (mirrors _recommend_len, src/common.jl)
 function _kj_recommend_len(x, f)
     λ = 1500.0 / f
@@ -87,8 +111,7 @@ end
 # UA boundary → Halfspace. Unit conversions mirror _write_env (src/common.jl):
 # density ratio ρ/1000 (g/cm³), attenuation in dB/λ, Francois-Garrison volume
 # attenuation applied through crci as the Fortran CRCI does for AttenUnit 'WF'
-function _kj_halfspace(b, f, fg)
-    T = Float64
+function _kj_halfspace(::Type{T}, b, f, fg) where {T}
     if b === RigidBoundary
         Halfspace{T}(:rigid)
     elseif b === PressureReleaseBoundary
@@ -117,11 +140,11 @@ source and receiver extent. Mirrors the Kraken blocks of `_write_env`
 (src/common.jl) and the auto-mesh rule of ReadEnvironmentMod.f90.
 """
 function _make_problem(pm::KrakenJL, tx, maxr)
-    T = Float64
     env = pm.env
     f = float(frequency(tx))
+    T = _kj_eltype(env, f)
     ssp = env.soundspeed
-    waterdepth = float(maximum(env.bathymetry))
+    waterdepth = T(maximum(env.bathymetry))
     fg = FrancoisGarrison(float(env.temperature), float(env.salinity),
                           float(env.pH), float(waterdepth / 2))
 
@@ -135,8 +158,8 @@ function _make_problem(pm::KrakenJL, tx, maxr)
     cn = Complex{T}[]
     if is_constant(ssp)
         c = float(value(ssp))
-        zn = [0.0, waterdepth]
-        cn = [crci(c, 0.0, f; volume=fg) for _ in 1:2]
+        zn = [zero(T), waterdepth]
+        cn = Complex{T}[crci(c, 0.0, f; volume=fg) for _ in 1:2]
     elseif ssp isa SampledFieldZ
         zrange = sort!(vcat(collect(ssp.zrange), -waterdepth); rev=true)
         for z in zrange
@@ -145,7 +168,8 @@ function _make_problem(pm::KrakenJL, tx, maxr)
             z == -waterdepth && break
         end
     else
-        for d in range(0.0, waterdepth; length=_kj_recommend_len(waterdepth, f))
+        for d in range(zero(T), waterdepth;
+                       length=_kj_recommend_len(_value(waterdepth), _value(f)))
             push!(zn, d)
             push!(cn, crci(float(ssp(-d)), 0.0, f; volume=fg))
         end
@@ -155,7 +179,7 @@ function _make_problem(pm::KrakenJL, tx, maxr)
         end
     end
     λ = maximum(ssp) / f
-    ng_water = round(Int, waterdepth / λ * pm.mesh_density)
+    ng_water = round(Int, _value(waterdepth / λ) * pm.mesh_density)
     push!(media, Medium{T}(0.0, waterdepth, zn, cn, zeros(Complex{T}, length(zn)),
                            ones(T, length(zn)), spline, ng_water))
 
@@ -169,7 +193,7 @@ function _make_problem(pm::KrakenJL, tx, maxr)
             cₛ₁, cₛ₂ = float(first(l.cₛ)), float(last(l.cₛ))
             λₗ = max(cₚ₁, cₛ₁, cₚ₂, cₛ₂) / f
             # Kraken manual recommends double mesh density for elastic media
-            ngl = round(Int, 2 * l.h / λₗ * pm.mesh_density)
+            ngl = round(Int, _value(2 * l.h / λₗ) * pm.mesh_density)
             push!(media, Medium{T}(depth, depth + l.h,
                 [depth, depth + l.h],
                 [crci(cₚ₁, in_dBperλ(l.δₚ), f; volume=fg),
@@ -184,13 +208,13 @@ function _make_problem(pm::KrakenJL, tx, maxr)
         seabed = ElasticBoundary(l.ρ, l.cₚ, l.cₛ, l.δₚ, l.δₛ)
     end
 
-    hstop = _kj_halfspace(env.surface, f, fg)
-    hsbot = _kj_halfspace(seabed, f, fg)
+    hstop = _kj_halfspace(T, env.surface, f, fg)
+    hsbot = _kj_halfspace(T, seabed, f, fg)
     push!(sigma, float(seabed === RigidBoundary || seabed === PressureReleaseBoundary ?
                        0.0 : seabed.σ))
 
-    rmax = isinf(pm.rmax) ? 1.01 * maxr : pm.rmax
-    prob = Problem{T}(f, media, sigma, hstop, hsbot, pm.clow, pm.chigh,
+    rmax = isinf(pm.rmax) ? T(1.01) * T(maxr) : T(pm.rmax)
+    prob = Problem{T}(T(f), media, sigma, hstop, hsbot, T(pm.clow), T(pm.chigh),
                       rmax / 1000)      # rmax in km, as read from the env file
 
     # base mesh counts (NG); 0 → auto rule of ReadEnvironmentMod.f90
@@ -222,14 +246,15 @@ function UnderwaterAcoustics.arrivals(pm::KrakenJL, tx1::AbstractAcousticSource,
     else
         max_c = 2 * max(max_c, maximum(pm.env.seabed.c))
     end
-    v = all(vi -> 0 ≤ vi ≤ max_c, res.vg) ? Vector{Union{Missing,Float64}}(res.vg) :
-        Vector{Union{Missing,Float64}}(fill(missing, length(res.k)))
+    T = real(eltype(res.k))
+    v = all(vi -> 0 ≤ vi ≤ max_c, res.vg) ? Vector{Union{Missing,T}}(res.vg) :
+        Vector{Union{Missing,T}}(fill(missing, length(res.k)))
 
     map(1:min(length(res.k), pm.nmodes)) do i
         # mode shapes on the solver's own mesh (finer than the wrapper's λ/10
         # resampling — see PORTING_NOTES §3)
         ψ = SampledField(res.phi[:, i]; z=-res.z)
-        ModeArrival{ComplexF64,typeof(ψ),Union{Missing,Float64},Float64}(
+        ModeArrival{Complex{T},typeof(ψ),Union{Missing,T},T}(
             i, res.k[i], ψ, v[i], ω / real(res.k[i]))
     end
 end

--- a/src/krakenjl/attenuation.jl
+++ b/src/krakenjl/attenuation.jl
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Attenuation conversions. Ports misc/AttenMod.f90 (CRCI, Franc_Garr).
+
+# dB → Nepers conversion constant used throughout Bellhop (20 log10 e)
+const DB_PER_NEPER = 8.6858896
+
+"""
+    crci(c, α_dbλ, freq; volume=nothing)
+
+Convert real sound speed + attenuation in dB/wavelength ('W' unit — the option
+the AcousticsToolbox wrapper writes) into a complex sound speed with positive
+imaginary part. Ports `CRCI` (misc/AttenMod.f90):
+
+    αT [Np/m] = α[dB/λ] · f / (8.6858896 · c)  (+ volume attenuation)
+    cimag     = αT · c² / ω
+    c̃         = c + i·cimag
+
+`volume` may be a `FrancoisGarrison` (wrapper option 'F') to add volume
+attenuation, or `:thorp` for Thorp.
+"""
+function crci(c, α_dbλ, freq; volume=nothing)
+    ω = 2π * freq
+    αT = iszero(c) ? zero(α_dbλ * freq / c) : α_dbλ * freq / (DB_PER_NEPER * c)
+    if volume === :thorp
+        αT += thorp(freq) / (DB_PER_NEPER * 1000)              # dB/km → Np/m
+    elseif volume isa FrancoisGarrison
+        αT += franc_garr(volume, freq / 1000) / (DB_PER_NEPER * 1000)
+    end
+    cimag = αT * c^2 / ω
+    complex(c, cimag)
+end
+
+"""
+    thorp(freq) -> α in dB/km
+
+Thorp volume attenuation, updated formula from JKPS Eq. 1.34 as in
+AttenMod.f90 ('T' option). `freq` in Hz.
+"""
+function thorp(freq)
+    f2 = (freq / 1000)^2
+    3.3e-3 + 0.11 * f2 / (1 + f2) + 44 * f2 / (4100 + f2) + 3.0e-4 * f2
+end
+
+"Francois-Garrison volume-attenuation parameters (misc/AttenMod.f90 module vars)."
+struct FrancoisGarrison{T<:Real}
+    temperature::T   # deg C
+    salinity::T      # psu
+    pH::T
+    z_bar::T         # depth [m]
+end
+
+FrancoisGarrison(t, s, pH, z̄) = FrancoisGarrison(promote(t, s, pH, z̄)...)
+
+"""
+    franc_garr(p, f) -> α in dB/km
+
+Francois-Garrison attenuation at frequency `f` [kHz]. Ports `Franc_Garr`
+(misc/AttenMod.f90).
+"""
+function franc_garr(p::FrancoisGarrison, f)
+    T, S, pH, z_bar = p.temperature, p.salinity, p.pH, p.z_bar
+    c = 1412 + 3.21 * T + 1.19 * S + 0.0167 * z_bar
+    # boric acid contribution
+    A1 = 8.86 / c * 10^(0.78 * pH - 5)
+    P1 = 1
+    f1 = 2.8 * sqrt(S / 35) * 10^(4 - 1245 / (T + 273))
+    # magnesium sulfate contribution
+    A2 = 21.44 * S / c * (1 + 0.025 * T)
+    P2 = 1 - 1.37e-4 * z_bar + 6.2e-9 * z_bar^2
+    f2 = 8.17 * 10^(8 - 1990 / (T + 273)) / (1 + 0.0018 * (S - 35))
+    # viscosity
+    P3 = 1 - 3.83e-5 * z_bar + 4.9e-10 * z_bar^2
+    A3 = T < 20 ?
+        4.937e-4 - 2.59e-5 * T + 9.11e-7 * T^2 - 1.5e-8 * T^3 :
+        3.964e-4 - 1.146e-5 * T + 1.45e-7 * T^2 - 6.5e-10 * T^3
+    A1 * P1 * (f1 * f^2) / (f1^2 + f^2) + A2 * P2 * (f2 * f^2) / (f2^2 + f^2) +
+        A3 * P3 * f^2
+end

--- a/src/krakenjl/bcimp.jl
+++ b/src/krakenjl/bcimp.jl
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Boundary-condition impedance. Ports BCImpedancecMod.f90 (complex, KRAKENC),
+# BCImpedanceMod.f90 (real, KRAKEN) and misc/PekRoot.f90.
+
+"""
+Pekeris branch of the square root exposing leaky modes (ports `PekerisRoot`,
+misc/PekRoot.f90).
+"""
+@inline pekeris_root(z::Complex) = real(z) >= 0 ? sqrt(z) : im * sqrt(-z)
+
+"""
+    bc_impedance(w, prob, x, bottop, hs, cnt) -> (f, g, ipower)
+
+Impedance functions (f, g) of the boundary for trial eigenvalue `x` (= k²).
+`bottop` is `:top` or `:bot`. The complex method ports `BCImpedance`
+(BCImpedancecMod.f90); the real method ports BCImpedanceMod.f90 (`ComplexFlag`
+= .FALSE. — the only value the reachable code paths use) and increments the
+mode counter `cnt` for an elastic bottom halfspace, as the Fortran does.
+"""
+function bc_impedance(w::MeshWorkspace{T,Complex{T}}, prob::Problem{T},
+                      x::Complex{T}, bottop::Symbol, hs::Halfspace{T},
+                      cnt) where {T}
+    ω² = (2π * prob.freq)^2
+    ipower = 0
+    yV = zeros(Complex{T}, 5)
+
+    local f::Complex{T}, g::Complex{T}
+    if hs.bc === :vacuum
+        f = one(Complex{T})
+        g = zero(Complex{T})
+        yV[1] = f; yV[2] = g
+    elseif hs.bc === :rigid
+        f = zero(Complex{T})
+        g = one(Complex{T})
+        yV[1] = f; yV[2] = g
+    else                                    # :acoustoelastic
+        if real(hs.cs) > 0                  # elastic halfspace
+            gammaS2 = x - ω² / hs.cs^2
+            gammaP2 = x - ω² / hs.cp^2
+            gammaS = pekeris_root(gammaS2)
+            gammaP = pekeris_root(gammaP2)
+            mu = hs.rho * hs.cs^2
+            yV[1] = (gammaS * gammaP - x) / mu
+            yV[2] = ((gammaS2 + x)^2 - 4 * gammaS * gammaP * x) * mu
+            yV[3] = 2 * gammaS * gammaP - gammaS2 - x
+            yV[4] = gammaP * (x - gammaS2)
+            yV[5] = gammaS * (gammaS2 - x)
+            f = ω² * yV[4]
+            g = yV[2]
+        else                                # acoustic halfspace
+            gammaP = pekeris_root(x - ω² / hs.cp^2)
+            f = gammaP
+            g = Complex{T}(hs.rho)
+        end
+    end
+
+    bottop === :top && (g = -g)    # top BC has the sign flipped vs bottom
+
+    # Shoot through elastic layers
+    nmedia = length(prob.media)
+    if bottop === :top && w.first_acoustic > 1
+        for medium in 1:w.first_acoustic-1
+            ipower = elastic_dn!(w, x, yV, ipower, medium)
+        end
+        f = ω² * yV[4]
+        g = yV[2]
+    elseif bottop === :bot && w.last_acoustic < nmedia
+        for medium in nmedia:-1:w.last_acoustic+1
+            ipower = elastic_up!(w, x, yV, ipower, medium)
+        end
+        f = ω² * yV[4]
+        g = yV[2]
+    end
+
+    f, g, ipower
+end
+
+function bc_impedance(w::MeshWorkspace{T,T}, prob::Problem{T}, x::T,
+                      bottop::Symbol, hs::Halfspace{T}, cnt) where {T}
+    ω² = (2π * prob.freq)^2
+    ipower = 0
+    yV = zeros(T, 5)
+
+    local f::Complex{T}, g::Complex{T}
+    if hs.bc === :vacuum
+        f = one(Complex{T}); g = zero(Complex{T})
+        yV[1] = real(f); yV[2] = real(g)
+    elseif hs.bc === :rigid
+        f = zero(Complex{T}); g = one(Complex{T})
+        yV[1] = real(f); yV[2] = real(g)
+    else                                    # :acoustoelastic
+        if real(hs.cs) > 0                  # elastic halfspace (real parts)
+            gammaS2 = x - ω² / real(hs.cs)^2
+            gammaP2 = x - ω² / real(hs.cp)^2
+            gammaS = real(sqrt(complex(gammaS2)))
+            gammaP = real(sqrt(complex(gammaP2)))
+            mu = hs.rho * real(hs.cs)^2
+            yV[1] = (gammaS * gammaP - x) / mu
+            yV[2] = (gammaS2 + x)^2 - 4 * gammaS * gammaP * x
+            yV[2] *= mu
+            yV[3] = 2 * gammaS * gammaP - gammaS2 - x
+            yV[4] = gammaP * (x - gammaS2)
+            yV[5] = gammaS * (gammaS2 - x)
+            f = Complex{T}(ω² * yV[4])
+            g = Complex{T}(yV[2])
+            real(g) > 0 && (cnt[] += 1)     # mode count contribution
+        else                                # acoustic halfspace
+            gammaP = sqrt(x - ω² / hs.cp^2)
+            # ComplexFlag = .FALSE.: real parts only
+            f = Complex{T}(real(gammaP))
+            g = Complex{T}(hs.rho)
+        end
+    end
+
+    bottop === :top && (g = -g)
+
+    nmedia = length(prob.media)
+    if bottop === :top && w.first_acoustic > 1
+        for medium in 1:w.first_acoustic-1
+            ipower = elastic_dn!(w, x, yV, ipower, medium)
+        end
+        f = Complex{T}(ω² * yV[4])
+        g = Complex{T}(yV[2])
+    elseif bottop === :bot && w.last_acoustic < nmedia
+        for medium in nmedia:-1:w.last_acoustic+1
+            ipower = elastic_up!(w, x, yV, ipower, medium)
+        end
+        f = Complex{T}(ω² * yV[4])
+        g = Complex{T}(yV[2])
+    end
+
+    f, g, ipower
+end
+
+"""
+Propagate through an elastic layer, shooting up from below, using the compound
+matrix formulation (ports `ElasticUP`, BCImpedance(c)Mod.f90). Mutates `yV`,
+returns the updated power-of-ten exponent.
+"""
+function elastic_up!(w::MeshWorkspace{T,X}, x, yV::Vector, ipower::Int,
+                     medium::Int) where {T,X}
+    two_x = 2 * x
+    two_h = 2 * w.h[medium]
+    four_h_x = 4 * w.h[medium] * x
+    j = w.loc[medium] + w.n[medium] + 1
+    xB3 = x * w.b3[j] - w.rho[j]
+
+    xV = similar(yV); zV = similar(yV)
+    # Euler's method for first step
+    zV[1] = yV[1] - (w.b1[j] * yV[4] - w.b2[j] * yV[5]) / 2
+    zV[2] = yV[2] - (-w.rho[j] * yV[4] - xB3 * yV[5]) / 2
+    zV[3] = yV[3] - (two_h * yV[4] + w.b4[j] * yV[5]) / 2
+    zV[4] = yV[4] - (xB3 * yV[1] + w.b2[j] * yV[2] - two_x * w.b4[j] * yV[3]) / 2
+    zV[5] = yV[5] - (w.rho[j] * yV[1] - w.b1[j] * yV[2] - four_h_x * yV[3]) / 2
+
+    # Modified midpoint method
+    for ii in w.n[medium]:-1:1
+        j -= 1
+        copyto!(xV, yV)
+        copyto!(yV, zV)
+        xB3 = x * w.b3[j] - w.rho[j]
+        zV[1] = xV[1] - (w.b1[j] * yV[4] - w.b2[j] * yV[5])
+        zV[2] = xV[2] - (-w.rho[j] * yV[4] - xB3 * yV[5])
+        zV[3] = xV[3] - (two_h * yV[4] + w.b4[j] * yV[5])
+        zV[4] = xV[4] - (xB3 * yV[1] + w.b2[j] * yV[2] - two_x * w.b4[j] * yV[3])
+        zV[5] = xV[5] - (w.rho[j] * yV[1] - w.b1[j] * yV[2] - four_h_x * yV[3])
+        if ii != 1     # scale if necessary
+            if abs(real(zV[2])) < FLOOR_
+                zV .*= ROOF; yV .*= ROOF
+                ipower -= IPOW_R
+            end
+            if abs(real(zV[2])) > ROOF
+                zV .*= FLOOR_; yV .*= FLOOR_
+                ipower -= IPOW_F
+            end
+        end
+    end
+
+    yV .= (xV .+ 2 .* yV .+ zV) ./ 4   # standard filter at the terminal point
+    ipower
+end
+
+"Ports `ElasticDN` (BCImpedance(c)Mod.f90) — shooting down from above."
+function elastic_dn!(w::MeshWorkspace{T,X}, x, yV::Vector, ipower::Int,
+                     medium::Int) where {T,X}
+    two_x = 2 * x
+    two_h = 2 * w.h[medium]
+    four_h_x = 4 * w.h[medium] * x
+    j = w.loc[medium] + 1
+    xB3 = x * w.b3[j] - w.rho[j]
+
+    xV = similar(yV); zV = similar(yV)
+    zV[1] = yV[1] + (w.b1[j] * yV[4] - w.b2[j] * yV[5]) / 2
+    zV[2] = yV[2] + (-w.rho[j] * yV[4] - xB3 * yV[5]) / 2
+    zV[3] = yV[3] + (two_h * yV[4] + w.b4[j] * yV[5]) / 2
+    zV[4] = yV[4] + (xB3 * yV[1] + w.b2[j] * yV[2] - two_x * w.b4[j] * yV[3]) / 2
+    zV[5] = yV[5] + (w.rho[j] * yV[1] - w.b1[j] * yV[2] - four_h_x * yV[3]) / 2
+
+    for ii in 1:w.n[medium]
+        j += 1
+        copyto!(xV, yV)
+        copyto!(yV, zV)
+        xB3 = x * w.b3[j] - w.rho[j]
+        zV[1] = xV[1] + (w.b1[j] * yV[4] - w.b2[j] * yV[5])
+        zV[2] = xV[2] + (-w.rho[j] * yV[4] - xB3 * yV[5])
+        zV[3] = xV[3] + (two_h * yV[4] + w.b4[j] * yV[5])
+        zV[4] = xV[4] + (xB3 * yV[1] + w.b2[j] * yV[2] - two_x * w.b4[j] * yV[3])
+        zV[5] = xV[5] + (w.rho[j] * yV[1] - w.b1[j] * yV[2] - four_h_x * yV[3])
+        if ii != w.n[medium]
+            if abs(real(zV[2])) < FLOOR_
+                zV .*= ROOF; yV .*= ROOF
+                ipower -= IPOW_R
+            end
+            if abs(real(zV[2])) > ROOF
+                zV .*= FLOOR_; yV .*= FLOOR_
+                ipower -= IPOW_F
+            end
+        end
+    end
+
+    yV .= (xV .+ 2 .* yV .+ zV) ./ 4
+    ipower
+end

--- a/src/krakenjl/dual.jl
+++ b/src/krakenjl/dual.jl
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# ForwardDiff support. The eigenvalue search (secant / Brent / bisection with
+# deflation and restarts) is iterative with value-dependent control flow, so
+# it is not run in dual arithmetic. Instead the search runs entirely on
+# ForwardDiff *values*, and each converged eigenvalue is made dual-exact with
+# a single Newton step of the (undeflated) characteristic function evaluated
+# in full dual arithmetic — by the implicit function theorem this transfers
+# the exact partials ∂x/∂θ = -(∂Δ/∂θ)/(∂Δ/∂x) regardless of how many
+# iterations the value search took. Eigenvectors, normalization,
+# perturbations, Richardson extrapolation and the mode summation are smooth
+# arithmetic and simply re-run with dual numbers. See PORTING_NOTES §3.
+
+import ForwardDiff
+
+_value(x::Real) = x
+_value(d::ForwardDiff.Dual) = _value(ForwardDiff.value(d))
+_value(z::Complex) = complex(_value(real(z)), _value(imag(z)))
+_valuetype(::Type{T}) where {T<:Real} = typeof(_value(one(T)))
+
+_value_halfspace(hs::Halfspace) =
+    Halfspace{Float64}(hs.bc, _value(hs.cp), _value(hs.cs), _value(hs.rho))
+
+_value_medium(m::Medium) =
+    Medium{Float64}(_value(m.z0), _value(m.z1), _value.(m.zn), _value.(m.cpn),
+                    _value.(m.csn), _value.(m.rhon), m.spline, m.ng)
+
+"Strip ForwardDiff partials from a `Problem` for the value-space search."
+_value_problem(prob::Problem) =
+    Problem{Float64}(_value(prob.freq), _value_medium.(prob.media),
+                     _value.(prob.sigma), _value_halfspace(prob.hstop),
+                     _value_halfspace(prob.hsbot), _value(prob.clow),
+                     _value(prob.chigh), _value(prob.rmax))
+
+"""
+    dual_newton(w, prob, x0) -> x
+
+One Newton step of the undeflated characteristic function in dual
+arithmetic, starting from the value-converged root `x0`. ∂Δ/∂x is computed
+by the same central-difference device `Normalize` (kraken(c).f90) uses for
+the admittance derivatives.
+"""
+function dual_newton(w::MeshWorkspace{T,X}, prob::Problem{T}, x0::X) where {T,X}
+    δ = 1.0e-7
+    noroots = X[]
+    d0, ip0, _ = funct(w, prob, x0, noroots, 0; deflate=false)
+    x1 = (1 - δ) * x0
+    x2 = (1 + δ) * x0
+    d1, ip1, _ = funct(w, prob, x1, noroots, 0; deflate=false)
+    d2, ip2, _ = funct(w, prob, x2, noroots, 0; deflate=false)
+    f1 = d1 * 10.0^(ip1 - ip0)      # bring to a common power of ten
+    f2 = d2 * 10.0^(ip2 - ip0)
+    dfdx = (f2 - f1) / (x2 - x1)
+    x0 - d0 / dfdx
+end
+
+function solve_modes(prob::Problem{T}, ngs::Vector{Int};
+                     complex_solver::Bool=true, robust::Bool=false,
+                     threads::Int=1) where {T<:ForwardDiff.Dual}
+    # 1. run the eigenvalue search on values only
+    core = _solve_modes_core(_value_problem(prob), ngs;
+                             complex_solver, robust, threads)
+
+    X = complex_solver ? Complex{T} : T
+    nmedia = length(prob.media)
+    w = MeshWorkspace{T,X}(nmedia)
+    Mmax = size(core.evmat, 2)
+    evmat = zeros(X, NSETS, Mmax)
+    extrap = zeros(X, NSETS, Mmax)
+
+    # 2. dual-correct the eigenvalues on each mesh used, replaying the
+    # Richardson extrapolation of Solve (kraken(c).f90) in dual arithmetic
+    for iset in 1:core.nsets_used
+        for m in 1:nmedia
+            w.n[m] = ngs[m] * NV[iset]
+            w.h[m] = (prob.media[m].z1 - prob.media[m].z0) / w.n[m]
+        end
+        initialize!(w, prob)
+        M = core.ms[iset]
+        if threads <= 1 || M < 2 * threads
+            for mode in 1:M
+                evmat[iset, mode] = dual_newton(w, prob, X(core.evmat[iset, mode]))
+            end
+        else       # funct only reads the workspace, so modes can be chunked
+            tasks = map(_chunks(M, threads)) do idxs
+                Threads.@spawn for mode in idxs
+                    evmat[iset, mode] = dual_newton(w, prob, X(core.evmat[iset, mode]))
+                end
+            end
+            foreach(wait, tasks)
+        end
+        extrap[iset, 1:M] .= evmat[iset, 1:M]
+        if iset > 1
+            for j in iset-1:-1:1, mode in 1:M
+                x1 = T(NV[j])^2
+                x2 = T(NV[iset])^2
+                f1 = extrap[j, mode]
+                f2 = extrap[j+1, mode]
+                extrap[j, mode] = f2 - (f1 - f2) / (x2 / x1 - 1)
+            end
+        end
+    end
+
+    # 3. eigenvectors / normalization / perturbations on the first mesh,
+    # entirely in dual arithmetic
+    for m in 1:nmedia
+        w.n[m] = ngs[m] * NV[1]
+        w.h[m] = (prob.media[m].z1 - prob.media[m].z0) / w.n[m]
+    end
+    initialize!(w, prob)
+    M = core.M
+    kpert = zeros(Complex{T}, Mmax)
+    vg = zeros(T, Mmax)
+    phi, zmesh = vector!(w, prob, evmat, kpert, vg, M, complex_solver, threads)
+
+    k = [sqrt(Complex{T}(extrap[1, i]) + kpert[i]) for i in 1:M]
+    if complex_solver
+        k = [_value(imag(ki)) > 0 ? Complex{T}(real(ki)) : ki for ki in k]
+    end
+    ModeResult{T}(k, phi[:, 1:M], zmesh, vg[1:M])
+end

--- a/src/krakenjl/field.jl
+++ b/src/krakenjl/field.jl
@@ -13,13 +13,8 @@ Linear-interpolation indices and weights of `ztab` into the (ascending) grid
 """
 function weight(z::AbstractVector, ztab::AbstractVector)
     n = length(z)
-    iz = similar(ztab, Int)
-    w = similar(ztab, Float64)
-    for (k, zt) in pairs(ztab)
-        i = clamp(searchsortedlast(z, zt), 1, n - 1)
-        iz[k] = i
-        w[k] = (zt - z[i]) / (z[i+1] - z[i])
-    end
+    iz = [clamp(searchsortedlast(z, zt), 1, n - 1) for zt in ztab]
+    w = [(ztab[k] - z[iz[k]]) / (z[iz[k]+1] - z[iz[k]]) for k in eachindex(iz)]
     iz, w
 end
 
@@ -27,7 +22,8 @@ end
 function tabulate_modes(res::ModeResult{T}, ztab::AbstractVector) where {T}
     iz, wts = weight(res.z, ztab)
     M = length(res.k)
-    phitab = Matrix{Complex{T}}(undef, length(ztab), M)
+    TT = promote_type(T, typeof(float(one(eltype(ztab)))))
+    phitab = Matrix{Complex{TT}}(undef, length(ztab), M)
     for m in 1:M, (k, i) in pairs(iz)
         phitab[k, m] = res.phi[i, m] + wts[k] * (res.phi[i+1, m] - res.phi[i, m])
     end
@@ -45,9 +41,11 @@ mode values at the receiver depths, `rxr` the receiver ranges [m].
 Range columns are independent, so they are chunked across threads (each
 column written by exactly one task — deterministic).
 """
-function evaluate_field(k::Vector{Complex{T}}, phiS::Vector{Complex{T}},
-                        phiR::Matrix{Complex{T}}, rxr::AbstractVector;
-                        incoherent::Bool=false, threads::Int=1) where {T}
+function evaluate_field(k::Vector{<:Complex}, phiS::Vector{<:Complex},
+                        phiR::Matrix{<:Complex}, rxr::AbstractVector;
+                        incoherent::Bool=false, threads::Int=1)
+    T = promote_type(real(eltype(k)), real(eltype(phiS)), real(eltype(phiR)),
+                     typeof(float(one(eltype(rxr)))))
     M = length(k)
     nz = size(phiR, 1)
     nr = length(rxr)
@@ -79,7 +77,7 @@ function evaluate_field(k::Vector{Complex{T}}, phiS::Vector{Complex{T}},
                 s = sqrt(s)
             end
             # cylindrical spreading (Option 'R')
-            P[iz, ir] = abs(r) > floatmin(T) ? s / sqrt(r) : s
+            P[iz, ir] = abs(_value(r)) > floatmin(_valuetype(T)) ? s / sqrt(r) : s
         end
     end
 

--- a/src/krakenjl/field.jl
+++ b/src/krakenjl/field.jl
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Pressure field from modes. Ports `Evaluate` (KrakenField/EvaluateMod.f90)
+# with the point-source, cylindrical-coordinates option ('R...C'/'R...I')
+# that the wrapper's .flp file requests, and `Weight`
+# (misc/calculateweights.f90) for mode interpolation at arbitrary depths.
+
+"""
+    weight(z, ztab) -> (iz, w)
+
+Linear-interpolation indices and weights of `ztab` into the (ascending) grid
+`z` (ports `Weight`, misc/calculateweights.f90).
+"""
+function weight(z::AbstractVector, ztab::AbstractVector)
+    n = length(z)
+    iz = similar(ztab, Int)
+    w = similar(ztab, Float64)
+    for (k, zt) in pairs(ztab)
+        i = clamp(searchsortedlast(z, zt), 1, n - 1)
+        iz[k] = i
+        w[k] = (zt - z[i]) / (z[i+1] - z[i])
+    end
+    iz, w
+end
+
+"Interpolate mode shapes onto depths `ztab` (Vector, kraken(c).f90 PhiTab)."
+function tabulate_modes(res::ModeResult{T}, ztab::AbstractVector) where {T}
+    iz, wts = weight(res.z, ztab)
+    M = length(res.k)
+    phitab = Matrix{Complex{T}}(undef, length(ztab), M)
+    for m in 1:M, (k, i) in pairs(iz)
+        phitab[k, m] = res.phi[i, m] + wts[k] * (res.phi[i+1, m] - res.phi[i, m])
+    end
+    phitab
+end
+
+"""
+    evaluate_field(k, phiS, phiR, rxr; incoherent=false, threads=1)
+        -> Matrix{Complex} (nz × nr)
+
+Mode summation for a point source in cylindrical coordinates (ports
+`Evaluate`, KrakenField/EvaluateMod.f90, Option 'R…C'/'R…I', zero array
+tilt). `phiS` are the mode values at the source depth, `phiR` the (nz × M)
+mode values at the receiver depths, `rxr` the receiver ranges [m].
+Range columns are independent, so they are chunked across threads (each
+column written by exactly one task — deterministic).
+"""
+function evaluate_field(k::Vector{Complex{T}}, phiS::Vector{Complex{T}},
+                        phiR::Matrix{Complex{T}}, rxr::AbstractVector;
+                        incoherent::Bool=false, threads::Int=1) where {T}
+    M = length(k)
+    nz = size(phiR, 1)
+    nr = length(rxr)
+    P = zeros(Complex{T}, nz, nr)
+    M <= 0 && return P     # if no modes, return vanishing pressure
+
+    factor = im * sqrt(2 * T(π)) * cis(T(π) / 4)
+    cnst = [factor * phiS[m] / sqrt(k[m]) for m in 1:M]     # point source
+    ik = [-im * k[m] for m in 1:M]                          # e^{i(ωt - kr)} form
+    incoherent && (ik = Complex{T}.(real.(ik)))             # incoherent case
+    cmat = permutedims(phiR) .* cnst   # (M × nz): const(m)·phi(m,iz), zero tilt
+
+    hank = [Vector{Complex{T}}(undef, M) for _ in 1:max(threads, 1)]
+    fill1range! = (ir, hnk) -> begin
+        r = rxr[ir]
+        @inbounds for m in 1:M
+            hnk[m] = exp(ik[m] * r)
+        end
+        @inbounds for iz in 1:nz
+            s = zero(Complex{T})
+            if !incoherent           # coherent case
+                for m in 1:M
+                    s += cmat[m, iz] * hnk[m]
+                end
+            else                     # incoherent case (as the Fortran: the
+                for m in 1:M         # square, not |·|², under the sqrt)
+                    s += (cmat[m, iz] * hnk[m])^2
+                end
+                s = sqrt(s)
+            end
+            # cylindrical spreading (Option 'R')
+            P[iz, ir] = abs(r) > floatmin(T) ? s / sqrt(r) : s
+        end
+    end
+
+    if threads <= 1 || nr < 2 * threads
+        for ir in 1:nr
+            fill1range!(ir, hank[1])
+        end
+    else
+        tasks = map(enumerate(_chunks(nr, threads))) do (t, idxs)
+            Threads.@spawn begin
+                local hnk = hank[t]
+                for ir in idxs
+                    fill1range!(ir, hnk)
+                end
+            end
+        end
+        foreach(wait, tasks)
+    end
+    P
+end

--- a/src/krakenjl/mesh.jl
+++ b/src/krakenjl/mesh.jl
@@ -208,8 +208,8 @@ Auto mesh count for a medium (ports the NG == 0 rule of ReadEnvironmentMod:
 20 points per wavelength at the last-read speed of the medium, min 10).
 """
 function auto_ng(med::Medium{T}, freq) where {T}
-    c = real(med.cpn[end])
-    iszero(med.csn[end]) || (c = real(med.csn[end]))
-    deltaz = c / freq / 20
-    max(floor(Int, (med.z1 - med.z0) / deltaz), 10)
+    c = _value(real(med.cpn[end]))
+    iszero(med.csn[end]) || (c = _value(real(med.csn[end])))
+    deltaz = c / _value(freq) / 20
+    max(floor(Int, _value(med.z1 - med.z0) / deltaz), 10)
 end

--- a/src/krakenjl/mesh.jl
+++ b/src/krakenjl/mesh.jl
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Finite-difference mesh setup. Ports `Initialize` (kraken.f90 / krakenc.f90)
+# and the SSP subtabulation (`cLinear`, `cCubic`, misc/sspMod.f90).
+
+"""
+    cspline_coefs(z, y) -> 4×n matrix
+
+Ports CSPLINE (misc/splinec.f90) for the iBCBeg = iBCEnd = 0 case, as used by
+`ReadSSP` (sspMod.f90). Same code as the BellhopJL port (spline SSPs share
+this routine upstream).
+"""
+function cspline_coefs(tau::Vector{T}, y::Vector{Complex{T}}) where {T}
+    n = length(tau)
+    C = zeros(Complex{T}, 4, n)
+    C[1, :] .= y
+    L = n - 1
+    for m in 2:n
+        C[3, m] = tau[m] - tau[m-1]
+        C[4, m] = (C[1, m] - C[1, m-1]) / C[3, m]
+    end
+    if n > 2
+        C[4, 1] = C[3, 3]
+        C[3, 1] = C[3, 2] + C[3, 3]
+        C[2, 1] = ((C[3, 2] + 2 * C[3, 1]) * C[4, 2] * C[3, 3] +
+                   C[3, 2]^2 * C[4, 3]) / C[3, 1]
+    else
+        C[4, 1] = 1
+        C[3, 1] = 1
+        C[2, 1] = 2 * C[4, 2]
+    end
+    for m in 2:L
+        g = -C[3, m+1] / C[4, m-1]
+        C[2, m] = g * C[2, m-1] + 3 * (C[3, m] * C[4, m+1] + C[3, m+1] * C[4, m])
+        C[4, m] = g * C[3, m-1] + 2 * (C[3, m] + C[3, m+1])
+    end
+    local g::Complex{T} = 0
+    if n == 2
+        C[2, n] = C[4, n]
+    elseif n == 3
+        C[2, n] = 2 * C[4, n]
+        C[4, n] = 1
+        g = -1 / C[4, n-1]
+    else
+        g = C[3, n-1] + C[3, n]
+        C[2, n] = ((C[3, n] + 2 * g) * C[4, n] * C[3, n-1] +
+                   C[3, n]^2 * (C[1, n-1] - C[1, n-2]) / C[3, n-1]) / g
+        g = -g / C[4, n-1]
+        C[4, n] = C[3, n-1]
+    end
+    if n > 2
+        C[4, n] = g * C[3, n-1] + C[4, n]
+        C[2, n] = (g * C[2, n-1] + C[2, n]) / C[4, n]
+    end
+    for j in L:-1:1
+        C[2, j] = (C[2, j] - C[3, j] * C[2, j+1]) / C[4, j]
+    end
+    for i in 2:n
+        dtau = C[3, i]
+        divdf1 = (C[1, i] - C[1, i-1]) / dtau
+        divdf3 = C[2, i-1] + C[2, i] - 2 * divdf1
+        C[3, i-1] = 2 * (divdf1 - C[2, i-1] - divdf3) / dtau
+        C[4, i-1] = (divdf3 / dtau) * (6 / dtau)
+    end
+    C[3, n] = C[3, L] + (tau[n] - tau[L]) * C[4, L]
+    C[4, n] = 0
+    C
+end
+
+"""
+    tabulate_ssp!(cp, cs, rhov, med, n1)
+
+Subtabulate the medium's SSP at the `n1` mesh points (ports `cLinear` /
+`cCubic`, sspMod.f90). Density is rho-linear in both cases (the spline path
+splines rho too upstream, but the wrapper writes piecewise-constant rho per
+medium, so linear is exact for all reachable inputs — see PORTING_NOTES §3).
+"""
+function tabulate_ssp!(cp::AbstractVector{Complex{T}}, cs, rhov, med::Medium{T},
+                       n1::Int) where {T}
+    zn = med.zn
+    npts = length(zn)
+    n = n1 - 1
+    h = (zn[npts] - zn[1]) / n
+    cpco = med.spline ? cspline_coefs(zn, med.cpn) : Matrix{Complex{T}}(undef, 0, 0)
+    csco = med.spline ? cspline_coefs(zn, med.csn) : Matrix{Complex{T}}(undef, 0, 0)
+    lay = 1
+    for iz in 1:n1
+        z = zn[1] + (iz - 1) * h
+        iz == n1 && (z = zn[npts])      # make sure no overshoot
+        while lay < npts - 1 && z > zn[lay+1]
+            lay += 1
+        end
+        if med.spline
+            hs = z - zn[lay]
+            # SPLINE (misc/splinec.f90): f = C1 + h(C2 + h(C3/2 + h C4/6))
+            cp[iz] = cpco[1, lay] + hs * (cpco[2, lay] + hs * (cpco[3, lay] / 2 +
+                     hs * cpco[4, lay] / 6))
+            cs[iz] = csco[1, lay] + hs * (csco[2, lay] + hs * (csco[3, lay] / 2 +
+                     hs * csco[4, lay] / 6))
+        else
+            r = (z - zn[lay]) / (zn[lay+1] - zn[lay])
+            cp[iz] = (1 - r) * med.cpn[lay] + r * med.cpn[lay+1]
+            cs[iz] = (1 - r) * med.csn[lay] + r * med.csn[lay+1]
+        end
+        r = (z - zn[lay]) / (zn[lay+1] - zn[lay])
+        rhov[iz] = (1 - r) * med.rhon[lay] + r * med.rhon[lay+1]
+    end
+    nothing
+end
+
+"""
+    initialize!(w, prob, iset) -> nothing
+
+Set up the finite-difference coefficient arrays for mesh `iset`. Ports
+`Initialize` (krakenc.f90 for `X = Complex{T}`, kraken.f90 for `X = T`).
+The caller must have set `w.n` and `w.h` (main loop of kraken(c).f90).
+"""
+function initialize!(w::MeshWorkspace{T,X}, prob::Problem{T}) where {T,X}
+    ω² = (2π * prob.freq)^2
+    nmedia = length(prob.media)
+    w.cmin = T(Inf)
+    w.first_acoustic = 0
+    w.last_acoustic = 0
+    w.loc[1] = 0
+
+    npoints = sum(w.n[1:nmedia]) + nmedia
+    resize!(w.b1, npoints);  fill!(w.b1, zero(X))
+    resize!(w.b1c, npoints); fill!(w.b1c, zero(T))
+    resize!(w.b2, npoints);  fill!(w.b2, zero(X))
+    resize!(w.b3, npoints);  fill!(w.b3, zero(X))
+    resize!(w.b4, npoints);  fill!(w.b4, zero(X))
+    resize!(w.rho, npoints); fill!(w.rho, zero(T))
+    cp = Vector{Complex{T}}(undef, npoints)
+    cs = Vector{Complex{T}}(undef, npoints)
+
+    elastic_flag = false
+    for medium in 1:nmedia
+        medium > 1 && (w.loc[medium] = w.loc[medium-1] + w.n[medium-1] + 1)
+        n1 = w.n[medium] + 1
+        ii = w.loc[medium] + 1
+
+        tabulate_ssp!(view(cp, ii:ii+w.n[medium]), view(cs, ii:ii+w.n[medium]),
+                      view(w.rho, ii:ii+w.n[medium]), prob.media[medium], n1)
+
+        if all(iszero, view(cs, ii:ii+w.n[medium]))     # acoustic medium
+            w.first_acoustic == 0 && (w.first_acoustic = medium)
+            w.last_acoustic = medium
+            for j in ii:ii+w.n[medium]
+                w.cmin = min(w.cmin, real(cp[j]))
+                if X <: Complex
+                    w.b1[j] = -2 + w.h[medium]^2 * ω² / cp[j]^2
+                else
+                    # KRAKEN keeps the real part in B1 and the imaginary part
+                    # of ω²/c² in B1C for the attenuation perturbation
+                    w.b1[j] = -2 + w.h[medium]^2 * real(ω² / cp[j]^2)
+                    w.b1c[j] = imag(ω² / cp[j]^2)
+                end
+            end
+        else                                            # elastic medium
+            prob.sigma[medium] == 0 && prob.sigma[medium+1] == 0 ||
+                error("Rough elastic interfaces are not allowed")
+            elastic_flag = true
+            two_h = 2 * w.h[medium]
+            for j in ii:ii+w.n[medium]
+                w.cmin = min(w.cmin, real(cs[j]))
+                cp2 = X <: Complex ? cp[j]^2 : real(cp[j]^2)
+                cs2 = X <: Complex ? cs[j]^2 : real(cs[j]^2)
+                w.b1[j] = two_h / (w.rho[j] * cs2)
+                w.b2[j] = two_h / (w.rho[j] * cp2)
+                w.b3[j] = 4 * two_h * w.rho[j] * cs2 * (cp2 - cs2) / cp2
+                w.b4[j] = two_h * (cp2 - 2 * cs2) / cp2
+                w.rho[j] = two_h * ω² * w.rho[j]
+            end
+        end
+    end
+
+    # (cLow, cHigh) adjustment from the halfspace properties
+    chigh = prob.chigh
+    if prob.hsbot.bc === :acoustoelastic
+        if real(prob.hsbot.cs) > 0
+            elastic_flag = true
+            w.cmin = min(w.cmin, real(prob.hsbot.cs))
+            X <: Complex || (chigh = min(chigh, real(prob.hsbot.cs)))
+        else
+            w.cmin = min(w.cmin, real(prob.hsbot.cp))
+        end
+    end
+    if prob.hstop.bc === :acoustoelastic
+        if real(prob.hstop.cs) > 0
+            elastic_flag = true
+            w.cmin = min(w.cmin, real(prob.hstop.cs))
+            X <: Complex || (chigh = min(chigh, real(prob.hstop.cs)))
+        else
+            w.cmin = min(w.cmin, real(prob.hstop.cp))
+        end
+    end
+
+    elastic_flag && (w.cmin *= T(0.85))     # reduce cMin for Scholte wave
+    # KRAKENC uses cLow = max(cLow, 0.99 cMin); KRAKEN uses max(cLow, cMin)
+    w.clow = X <: Complex ? max(prob.clow, T(0.99) * w.cmin) :
+                            max(prob.clow, w.cmin)
+    w.chigh = chigh
+    nothing
+end
+
+"""
+Auto mesh count for a medium (ports the NG == 0 rule of ReadEnvironmentMod:
+20 points per wavelength at the last-read speed of the medium, min 10).
+"""
+function auto_ng(med::Medium{T}, freq) where {T}
+    c = real(med.cpn[end])
+    iszero(med.csn[end]) || (c = real(med.csn[end]))
+    deltaz = c / freq / 20
+    max(floor(Int, (med.z1 - med.z0) / deltaz), 10)
+end

--- a/src/krakenjl/modes.jl
+++ b/src/krakenjl/modes.jl
@@ -26,7 +26,7 @@ function inverse_iteration!(phi::Vector{X}, d::Vector{X}, e::Vector{X}) where {X
             sum(j -> abs(real(e[j])) + abs(imag(e[j])), 2:n)
 
     # factor of 100: some Scholte modes weren't getting amplified enough (mbp 8/2010)
-    eps3 = 100 * eps(typeof(norm_)) * norm_
+    eps3 = 100 * eps(_valuetype(typeof(norm_))) * norm_
     uk = real(n)
     eps4 = uk * eps3
     uk = eps4 / sqrt(uk)

--- a/src/krakenjl/modes.jl
+++ b/src/krakenjl/modes.jl
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Eigenvectors, normalization and perturbations. Ports Vector / Normalize /
+# ScatterLoss (kraken.f90, krakenc.f90), InverseIterationMod.f90 and
+# KupIng (Kraken/Scattering.f90).
+
+"""
+    inverse_iteration!(phi, d, e) -> iError
+
+Inverse iteration for the eigenvector of a singular tridiagonal symmetric
+matrix (ports `InverseIterationD`/`InverseIterationZ`,
+InverseIterationMod.f90 — a modified EISPACK TINVIT). `d` is the diagonal,
+`e[2:n]` the sub-diagonal (`e[1]`, `e[n+1]` arbitrary). Generic over
+real/complex element type.
+"""
+function inverse_iteration!(phi::Vector{X}, d::Vector{X}, e::Vector{X}) where {X}
+    n = length(d)
+    maxiteration = 3
+    rv1 = Vector{X}(undef, n)
+    rv2 = Vector{X}(undef, n)
+    rv3 = Vector{X}(undef, n)
+    rv4 = Vector{X}(undef, n)
+
+    # infinity norm of the matrix (L1 of real+imag parts in the Fortran)
+    norm_ = sum(j -> abs(real(d[j])) + abs(imag(d[j])), 1:n) +
+            sum(j -> abs(real(e[j])) + abs(imag(e[j])), 2:n)
+
+    # factor of 100: some Scholte modes weren't getting amplified enough (mbp 8/2010)
+    eps3 = 100 * eps(typeof(norm_)) * norm_
+    uk = real(n)
+    eps4 = uk * eps3
+    uk = eps4 / sqrt(uk)
+
+    # elimination with interchanges
+    xu = one(X)
+    u = d[1]
+    v = e[2]
+    for i in 2:n
+        if abs(e[i]) >= abs(u)
+            xu = u / e[i]
+            rv4[i] = xu
+            rv1[i-1] = e[i]
+            rv2[i-1] = d[i]
+            rv3[i-1] = e[i+1]
+            u = v - xu * rv2[i-1]
+            v = -xu * rv3[i-1]
+        else
+            xu = e[i] / u
+            rv4[i] = xu
+            rv1[i-1] = u
+            rv2[i-1] = v
+            rv3[i-1] = zero(X)
+            u = d[i] - xu * v
+            v = e[i+1]
+        end
+    end
+    u == 0 && (u = X(eps3))
+    rv3[n-1] = zero(X)
+    rv1[n] = u
+    rv2[n] = zero(X)
+    rv3[n] = zero(X)
+
+    # main loop of inverse iteration
+    fill!(phi, X(uk))
+    for _ in 1:maxiteration
+        # back substitution
+        for i in n:-1:1
+            phi[i] = (phi[i] - u * rv2[i] - v * rv3[i]) / rv1[i]
+            v = u
+            u = phi[i]
+        end
+        # norm of vector; test for doneness
+        norm_ = sum(x -> abs(real(x)) + abs(imag(x)), phi)
+        norm_ >= 1 && return 0
+
+        xu = X(eps4 / norm_)     # scale the vector down
+        phi .*= xu
+        # forward elimination
+        for i in 2:n
+            u = phi[i]
+            if rv1[i-1] == e[i]  # rows switched during triangularization
+                u = phi[i-1]
+                phi[i-1] = phi[i]
+            end
+            phi[i] = u - rv4[i] * phi[i-1]
+        end
+    end
+    -1   # failure to converge
+end
+
+"""
+Kuperman–Ingenito interfacial-roughness perturbation (ports `KupIng`,
+Kraken/Scattering.f90). `P` = pressure at the interface, `U` = P'/ρ.
+"""
+function kuping(sigma::T, eta1sq::Complex{T}, rho1::T, eta2sq::Complex{T},
+                rho2::T, P::Complex{T}, U::Complex{T}) where {T}
+    sigma == 0 && return zero(Complex{T})
+    scatter_root(z) = real(z) >= 0 ? sqrt(z) : -im * sqrt(-z)
+    eta1 = scatter_root(eta1sq)
+    eta2 = scatter_root(eta2sq)
+    del = rho1 * eta2 + rho2 * eta1
+    del == 0 && return zero(Complex{T})
+    a11 = (eta1sq - eta2sq) / 2 - (rho2 * eta1sq - rho1 * eta2sq) * (eta1 + eta2) / del
+    a12 = im * (rho2 - rho1)^2 * eta1 * eta2 / del
+    a21 = -im * (rho2 * eta1sq - rho1 * eta2sq)^2 / (rho1 * rho2 * del)
+    a22 = (eta1sq - eta2sq) / 2 + (rho2 - rho1) * eta1 * eta2 * (eta1 + eta2) / del
+    -sigma^2 * (-a21 * P^2 + (a11 - a22) * P * U + a12 * U^2)
+end
+
+"""
+    scatter_loss(w, prob, phi, x) -> Complex
+
+Interfacial scatter-loss perturbation to k² (ports `ScatterLoss`,
+kraken(c).f90). `phi` is the normalized eigenvector on the acoustic mesh,
+`x` the eigenvalue (real for KRAKEN, complex for KRAKENC).
+"""
+function scatter_loss(w::MeshWorkspace{T,X}, prob::Problem{T},
+                      phi::AbstractVector{Complex{T}}, x) where {T,X}
+    ω² = (2π * prob.freq)^2
+    pert = zero(Complex{T})
+    j = 1
+    L = w.loc[w.first_acoustic]
+    nmedia = length(prob.media)
+
+    for medium in w.first_acoustic-1:w.last_acoustic
+        local rho1::T, eta1sq::Complex{T}, U::Complex{T}
+        if medium == w.first_acoustic - 1    # top properties
+            if prob.hstop.bc === :acoustoelastic
+                rho1 = prob.hstop.rho
+                eta1sq = x - ω² / prob.hstop.cp^2
+                root1 = X <: Complex ? pekeris_root(eta1sq) : sqrt(eta1sq)
+                U = root1 * phi[1] / prob.hstop.rho
+            elseif prob.hstop.bc === :vacuum
+                rho1 = T(1.0e-9)
+                eta1sq = one(Complex{T})
+                rho_inside = w.rho[w.loc[w.first_acoustic]+1]
+                U = phi[2] / w.h[w.first_acoustic] / rho_inside
+            else                             # rigid
+                rho1 = T(1.0e9)
+                eta1sq = one(Complex{T})
+                U = zero(Complex{T})
+            end
+        else
+            h2 = w.h[medium]^2
+            j += w.n[medium]
+            L = w.loc[medium] + w.n[medium] + 1
+            rho1 = w.rho[L]
+            eta1sq = (2 + w.b1[L]) / h2 - x
+            U = (-phi[j-1] - (w.b1[L] - h2 * x) * phi[j] / 2) / (w.h[medium] * rho1)
+        end
+
+        local rho2::T, eta2sq::Complex{T}
+        if medium == w.last_acoustic         # bottom properties
+            if prob.hsbot.bc === :acoustoelastic
+                rho2 = prob.hsbot.rho
+                eta2sq = ω² / prob.hsbot.cp^2 - x
+            elseif prob.hsbot.bc === :vacuum
+                rho2 = T(1.0e-9)
+                eta2sq = one(Complex{T})
+            else                             # rigid
+                rho2 = T(1.0e9)
+                eta2sq = one(Complex{T})
+            end
+        else
+            rho2 = w.rho[L+1]
+            eta2sq = (2 + w.b1[L+1]) / w.h[medium+1]^2 - x
+        end
+
+        pert += kuping(prob.sigma[medium+1], eta1sq, rho1, eta2sq, rho2,
+                       phi[j], U)
+    end
+    pert
+end
+
+"""
+    normalize!(phi, w, prob, x, iturningpoint, complex_solver)
+        -> (vg, pert)
+
+Normalize the eigenvector and compute the group speed and (real path) the
+attenuation perturbation (ports `Normalize` of krakenc.f90 for the complex
+path and kraken.f90 for the real path). Mutates `phi` in place. Returns the
+group speed (0 for the real path — KRAKEN leaves VG unset) and the
+perturbation to k² *excluding* interfacial scatter.
+"""
+function normalize!(phi::AbstractVector{Complex{T}}, w::MeshWorkspace{T,X},
+                    prob::Problem{T}, x, iturningpoint::Int) where {T,X}
+    ω = 2π * prob.freq
+    ω² = ω^2
+    ntotal1 = length(phi)
+    sqnorm = zero(Complex{T})
+    slow = zero(Complex{T})
+    pert = zero(Complex{T})
+
+    # contribution from the top halfspace
+    if prob.hstop.bc === :acoustoelastic
+        if X <: Complex
+            slow += phi[1]^2 / (2 * sqrt(x - ω² / prob.hstop.cp^2)) /
+                    (prob.hstop.rho * prob.hstop.cp^2)
+        else
+            del = im * imag(sqrt(complex(x - ω² / prob.hstop.cp^2)))
+            pert -= del * phi[1]^2 / prob.hstop.rho
+            slow += phi[1]^2 / (2 * sqrt(complex(x - real(ω² / prob.hstop.cp^2)))) /
+                    (prob.hstop.rho * real(prob.hstop.cp)^2)
+        end
+    end
+
+    # contribution from the volume
+    L = w.loc[w.first_acoustic]
+    j = 1
+    for medium in w.first_acoustic:w.last_acoustic
+        L += 1
+        rho_medium = w.rho[L]
+        rho_omega_h2 = rho_medium * ω² * w.h[medium]^2
+
+        # top interface
+        sqnorm += w.h[medium] * phi[j]^2 / rho_medium / 2
+        slow += w.h[medium] * (w.b1[L] + 2) * phi[j]^2 / rho_omega_h2 / 2
+        X <: Complex ||
+            (pert += w.h[medium] * im * w.b1c[L] * phi[j]^2 / rho_medium / 2)
+
+        # medium
+        L1 = L + 1
+        L += w.n[medium] - 1
+        j1 = j + 1
+        j += w.n[medium] - 1
+        for (LL, jj) in zip(L1:L, j1:j)
+            sqnorm += w.h[medium] * phi[jj]^2 / rho_medium
+            slow += w.h[medium] * (w.b1[LL] + 2) * phi[jj]^2 / rho_omega_h2
+            X <: Complex ||
+                (pert += w.h[medium] * im * w.b1c[LL] * phi[jj]^2 / rho_medium)
+        end
+
+        # bottom interface
+        L += 1
+        j += 1
+        sqnorm += w.h[medium] * phi[j]^2 / rho_medium / 2
+        slow += w.h[medium] * (w.b1[L] + 2) * phi[j]^2 / rho_omega_h2 / 2
+        X <: Complex ||
+            (pert += w.h[medium] * im * w.b1c[L] * phi[j]^2 / rho_medium / 2)
+    end
+
+    # contribution from the bottom halfspace
+    if prob.hsbot.bc === :acoustoelastic
+        if X <: Complex
+            slow += phi[j]^2 / (2 * sqrt(x - ω² / prob.hsbot.cp^2)) /
+                    (prob.hsbot.rho * prob.hsbot.cp^2)
+        else
+            # loop-length formula that works for leaky modes (kraken.f90):
+            # difference of the ComplexFlag=.TRUE./.FALSE. impedances — which
+            # is nonzero only for an acoustic halfspace (elastic halfspaces
+            # ignore ComplexFlag in BCImpedanceMod.f90)
+            if real(prob.hsbot.cs) == 0
+                cnt = Ref(0)
+                f1, g1, _ = bc_impedance(w, prob, x, :bot, prob.hsbot, cnt)
+                gammaP = sqrt(x - ω² / prob.hsbot.cp^2)
+                f2, g2 = gammaP, Complex{T}(prob.hsbot.rho)
+                del = f2 / g2 - f1 / g1
+                pert -= del * phi[j]^2
+            end
+            # group velocity still uses the perturbation method
+            slow += phi[j]^2 / (2 * sqrt(complex(x - real(ω² / prob.hsbot.cp^2)))) /
+                    (prob.hsbot.rho * real(prob.hsbot.cp)^2)
+        end
+    end
+
+    # derivative of the top and bottom admittances w.r.t. x
+    x1 = T(0.9999999) * x
+    x2 = T(1.0000001) * x
+    cnt = Ref(0)
+    ftop1, gtop1, _ = bc_impedance(w, prob, x1, :top, prob.hstop, cnt)
+    ftop2, gtop2, _ = bc_impedance(w, prob, x2, :top, prob.hstop, cnt)
+    drhodx = zero(Complex{T})
+    gtop1 != 0 && (drhodx = (ftop2 / gtop2 - ftop1 / gtop1) / (x2 - x1))
+
+    fbot1, gbot1, _ = bc_impedance(w, prob, x1, :bot, prob.hsbot, cnt)
+    fbot2, gbot2, _ = bc_impedance(w, prob, x2, :bot, prob.hsbot, cnt)
+    detadx = zero(Complex{T})
+    gbot1 != 0 && (detadx = (fbot2 / gbot2 - fbot1 / gbot1) / (x2 - x1))
+
+    # scale the mode
+    if X <: Complex
+        rn = sqnorm - drhodx * phi[1]^2 + detadx * phi[ntotal1]^2
+        scalefactor = 1 / sqrt(rn)      # generally a complex number
+        real(scalefactor * phi[iturningpoint]) < 0 && (scalefactor = -scalefactor)
+    else
+        rn = real(sqnorm) - real(drhodx) * real(phi[1])^2 +
+             real(detadx) * real(phi[ntotal1])^2
+        rn <= 0 && (rn = -rn)           # grid-too-coarse warning case
+        scalefactor = Complex{T}(1 / sqrt(rn))
+        real(phi[iturningpoint]) < 0 && (scalefactor = -scalefactor)
+    end
+
+    phi .*= scalefactor
+    slow *= scalefactor^2 * ω / sqrt(Complex{T}(x))
+    pert *= scalefactor^2
+
+    vg = X <: Complex ? real(1 / slow) : zero(T)   # KRAKEN leaves VG unset
+    vg, pert
+end
+
+"""
+    vector!(w, prob, evmat, kpert, vg, M, complex_solver, threads)
+        -> (phi, zmesh)
+
+Inverse iteration for all `M` eigenvectors on the first mesh (ports `Vector`,
+kraken(c).f90). Fills `kpert` (perturbation incl. scatter loss) and `vg`.
+Modes are independent, so they are optionally chunked across threads (each
+task with `local` workspaces; deterministic — each mode writes its own
+column).
+"""
+function vector!(w::MeshWorkspace{T,X}, prob::Problem{T}, evmat::Matrix{X},
+                 kpert::Vector{Complex{T}}, vg::Vector{T}, M::Int,
+                 complex_solver::Bool, threads::Int) where {T,X}
+    ntotal = sum(w.n[w.first_acoustic:w.last_acoustic])
+    ntotal1 = ntotal + 1
+
+    # tabulate z-coordinates and off-diagonals of the matrix
+    z = zeros(T, ntotal1)
+    e0 = zeros(X, ntotal1 + 1)
+    j = 1
+    z[1] = prob.media[w.first_acoustic].z0
+    h_rho = zero(T)
+    for medium in w.first_acoustic:w.last_acoustic
+        h_rho = w.h[medium] * w.rho[w.loc[medium]+1]   # rho at top of layer
+        for jj in 1:w.n[medium]
+            e0[j+jj] = 1 / h_rho
+            z[j+jj] = z[j] + w.h[medium] * jj
+        end
+        j += w.n[medium]
+    end
+    e0[ntotal1+1] = 1 / h_rho    # dummy value; never used
+
+    phi = zeros(Complex{T}, ntotal1, M)
+
+    solve1mode! = (mode, d, e, phim) -> begin
+        x = evmat[1, mode]
+        cnt = Ref(0)
+        copyto!(e, e0)
+
+        # corner element requires the top impedance
+        ftop, gtop, _ = bc_impedance(w, prob, x, :top, prob.hstop, cnt)
+        if gtop == 0
+            d[1] = one(X)
+            e[2] = zero(X)
+        else
+            L = w.loc[w.first_acoustic] + 1
+            xh2 = x * w.h[w.first_acoustic]^2
+            hr = w.h[w.first_acoustic] * w.rho[L]
+            fg = X <: Complex ? ftop / gtop : real(ftop / gtop)
+            d[1] = (w.b1[L] - xh2) / hr / 2 + fg
+        end
+
+        # set up the diagonal; iTurningPoint = index closest to the surface
+        # where the mode is still oscillatory
+        iturningpoint = ntotal
+        jj = 1
+        L = w.loc[w.first_acoustic] + 1
+        for medium in w.first_acoustic:w.last_acoustic
+            xh2 = x * w.h[medium]^2
+            hr = w.h[medium] * w.rho[w.loc[medium]+1]
+            if medium >= w.first_acoustic + 1
+                L += 1
+                d[jj] = (d[jj] + (w.b1[L] - xh2) / hr) / 2
+            end
+            for _ in 1:w.n[medium]
+                jj += 1
+                L += 1
+                d[jj] = (w.b1[L] - xh2) / hr
+                if real(w.b1[L] - xh2) + 2 > 0    # turning point nearest top
+                    iturningpoint = min(jj, iturningpoint)
+                end
+            end
+        end
+
+        # corner element requires the bottom impedance
+        fbot, gbot, _ = bc_impedance(w, prob, x, :bot, prob.hsbot, cnt)
+        if gbot == 0
+            d[ntotal1] = one(X)
+            e[ntotal1] = zero(X)
+        else
+            fg = X <: Complex ? fbot / gbot : real(fbot / gbot)
+            d[ntotal1] = d[ntotal1] / 2 - fg
+        end
+
+        phix = Vector{X}(undef, ntotal1)
+        ierr = inverse_iteration!(phix, d, e)
+        if ierr != 0
+            fill!(phim, zero(Complex{T}))   # zero out the errant eigenvector
+        else
+            phim .= Complex{T}.(phix)
+            vgm, pert = normalize!(phim, w, prob, x, iturningpoint)
+            vg[mode] = vgm
+            kpert[mode] = pert + scatter_loss(w, prob, phim, x)
+        end
+    end
+
+    if threads <= 1 || M < 2 * threads
+        d = Vector{X}(undef, ntotal1)
+        e = Vector{X}(undef, ntotal1 + 1)
+        for mode in 1:M
+            solve1mode!(mode, d, e, view(phi, :, mode))
+        end
+    else
+        tasks = map(_chunks(M, threads)) do idxs
+            Threads.@spawn begin
+                local td = Vector{X}(undef, ntotal1)
+                local te = Vector{X}(undef, ntotal1 + 1)
+                for mode in idxs
+                    solve1mode!(mode, td, te, view(phi, :, mode))
+                end
+            end
+        end
+        foreach(wait, tasks)
+    end
+
+    phi, z
+end
+
+"Partition `1:n` into at most `k` contiguous, near-equal chunks."
+_chunks(n, k) = [(1 + div((j - 1) * n, k)):div(j * n, k) for j in 1:min(k, n)]

--- a/src/krakenjl/solve.jl
+++ b/src/krakenjl/solve.jl
@@ -450,6 +450,15 @@ kraken.f90 / krakenc.f90). `ngs` are the base mesh counts per medium.
 function solve_modes(prob::Problem{T}, ngs::Vector{Int};
                      complex_solver::Bool=true, robust::Bool=false,
                      threads::Int=1) where {T}
+    _solve_modes_core(prob, ngs; complex_solver, robust, threads).res
+end
+
+# Core driver, additionally returning the per-mesh eigenvalues (`evmat`), the
+# per-mesh mode counts after the spectral trim (`ms`) and the number of
+# meshes used — needed by the ForwardDiff dual-correction pass (dual.jl).
+function _solve_modes_core(prob::Problem{T}, ngs::Vector{Int};
+                           complex_solver::Bool=true, robust::Bool=false,
+                           threads::Int=1) where {T}
     X = complex_solver ? Complex{T} : T
     nmedia = length(prob.media)
     w = MeshWorkspace{T,X}(nmedia)
@@ -467,8 +476,11 @@ function solve_modes(prob::Problem{T}, ngs::Vector{Int};
     M = 0
     err = T(Inf)
     no_elastic_layers = true
+    ms = zeros(Int, NSETS)      # M after the spectral trim, per mesh
+    nsets_used = 0
 
     for iset in 1:NSETS
+        nsets_used = iset
         for m in 1:nmedia
             w.n[m] = ngs[m] * NV[iset]
             w.h[m] = (prob.media[m].z1 - prob.media[m].z0) / w.n[m]
@@ -516,6 +528,7 @@ function solve_modes(prob::Problem{T}, ngs::Vector{Int};
         end
         M = Mtrim
         M == 0 && error("KrakenJL: No modes for given phase speed interval")
+        ms[iset] = M
 
         if iset == 1     # compute the eigenvectors on the first mesh
             phi, zmesh = vector!(w, prob, evmat, kpert, vg, M, complex_solver,
@@ -557,5 +570,6 @@ function solve_modes(prob::Problem{T}, ngs::Vector{Int};
         k = [imag(ki) > 0 ? Complex{T}(real(ki)) : ki for ki in k]
     end
 
-    ModeResult{T}(k, phi[:, 1:M], zmesh, vg[1:M])
+    (res=ModeResult{T}(k, phi[:, 1:M], zmesh, vg[1:M]),
+     evmat=evmat, ms=ms, nsets_used=nsets_used, M=M)
 end

--- a/src/krakenjl/solve.jl
+++ b/src/krakenjl/solve.jl
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Eigenvalue search. Ports FUNCT / AcousticLayers / Solve / Solve1 / Solve2 /
+# Bisection (kraken.f90, krakenc.f90), ZBRENTX (RootFinderBrent.f90) and
+# ZSecantX / ZSecantCX (misc/RootFinderSecantMod.f90).
+
+"""
+    acoustic_layers(w, x, f, g, ipower) -> (f, g, ipower, modecount)
+
+Shoot (towards the surface) through the acoustic layers (ports
+`AcousticLayers`, kraken(c).f90). Generic over real (KRAKEN) / complex
+(KRAKENC) `x`, `f`, `g`. `count_modes` enables the Sturm sign-change count of
+the real path.
+"""
+function acoustic_layers(w::MeshWorkspace{T,X}, x, f, g, ipower::Int;
+                         count_modes::Bool=false) where {T,X}
+    modecount = 0
+    w.first_acoustic == 0 && return f, g, ipower, modecount
+
+    for medium in w.last_acoustic:-1:w.first_acoustic
+        h2k2 = w.h[medium]^2 * x
+        ii = w.loc[medium] + w.n[medium] + 1
+        rho_medium = w.rho[w.loc[medium]+1]  # density at top of each medium
+
+        p1 = -2 * g
+        p2 = (w.b1[ii] - h2k2) * g - 2 * w.h[medium] * f * rho_medium
+        p0 = zero(p2)
+
+        # Shoot (towards surface) through a single medium
+        for jj in w.loc[medium]+w.n[medium]:-1:w.loc[medium]+1
+            p0 = p1
+            p1 = p2
+            p2 = (h2k2 - w.b1[jj]) * p1 - p0
+
+            if count_modes && real(p0 * p1) <= 0
+                modecount += 1
+            end
+
+            while abs(real(p2)) > ROOF          # scale if necessary
+                p0 *= FLOOR_
+                p1 *= FLOOR_
+                p2 *= FLOOR_
+                ipower -= IPOW_F
+            end
+        end
+
+        # f = P'/rho and g = -P since f P + g P'/rho = 0
+        f = -(p2 - p0) / (2 * w.h[medium]) / rho_medium
+        g = -p1
+    end
+    f, g, ipower, modecount
+end
+
+"""
+    funct(w, prob, x, roots, nroots; count_modes=false, deflate=true)
+        -> (delta, ipower, modecount)
+
+The dispersion relation: FUNCT(x) = 0 at the eigenvalues. Ports `FUNCT`
+(krakenc.f90 for complex `x`, kraken.f90 for real `x`). `roots[1:nroots]` are
+previously found roots for deflation (KRAKENC always deflates; KRAKEN only
+when elastic layers are present — the caller controls via `deflate`).
+"""
+function funct(w::MeshWorkspace{T,X}, prob::Problem{T}, x,
+               roots::AbstractVector, nroots::Int;
+               count_modes::Bool=false, deflate::Bool=true) where {T,X}
+    cnt = Ref(0)
+    fc, gc, ipower = bc_impedance(w, prob, x, :bot, prob.hsbot, cnt)  # bottom
+    if X <: Complex
+        f, g = fc, gc
+    else
+        f, g = real(fc), real(gc)
+    end
+    f, g, ipower, modecount = acoustic_layers(w, x, f, g, ipower; count_modes)
+    fbot, gbot, ipowerbot = bc_impedance(w, prob, x, :top, prob.hstop, cnt)  # top
+
+    if X <: Complex
+        delta = f * gbot - g * fbot
+    else
+        delta = real(f * gbot - g * fbot)
+        g * delta > 0 && (modecount += 1)
+    end
+    ipower += ipowerbot
+    modecount += cnt[]
+
+    # Deflate previous roots
+    if deflate && nroots > 0
+        for j in 1:nroots
+            delta = delta / (x - roots[j])
+            while abs(real(delta)) < FLOOR_ && abs(delta) > 0
+                delta *= ROOF
+                ipower -= IPOW_R
+            end
+            while abs(real(delta)) > ROOF
+                delta *= FLOOR_
+                ipower -= IPOW_F
+            end
+        end
+    end
+
+    delta, ipower, modecount
+end
+
+"""
+    secant(x2, tolerance, maxiteration, fun) -> (x2, errmsg)
+
+Secant method with extended-range function values (ports `ZSecantX` /
+`ZSecantCX`, misc/RootFinderSecantMod.f90). `fun(x) -> (f, ipower)`.
+"""
+function secant(x2::X, tolerance::Real, maxiteration::Int, fun) where {X}
+    tolerance > 0 || return x2, "Non-positive tolerance specified"
+    # ZSecantX uses 10·tolerance for the second point, ZSecantCX uses 100·
+    x1 = x2 + (X <: Complex ? 100 : 10) * tolerance
+    f1, ipower1 = fun(x1)
+    for _ in 1:maxiteration
+        x0 = x1
+        f0 = f1
+        ipower0 = ipower1
+        x1 = x2
+        f1, ipower1 = fun(x1)
+
+        # block overflows by forcing the shift to be bounded
+        cnum = f1 * (x1 - x0)
+        cden = f1 - f0 * 10.0^(ipower0 - ipower1)
+        shift = abs(cnum) >= abs(cden * x1) ? X(0.1 * tolerance) : cnum / cden
+        x2 = x1 - shift
+        if abs(x2 - x1) + abs(x2 - x0) < tolerance
+            return x2, ""
+        end
+    end
+    x2, "Failure to converge in RootFinderSecant"
+end
+
+"""
+    zbrentx(a, b, t, fun) -> (x, errmsg)
+
+Brent's method, extended-range version (ports `ZBRENTX`,
+RootFinderBrent.f90). `fun(x) -> (f, ipower)` with f·10^ipower the true value.
+"""
+function zbrentx(a::T, b::T, t::T, fun) where {T<:Real}
+    macheps = T(1.0e-16)
+    fa, iexpa = fun(a)
+    fb, iexpb = fun(b)
+    if (fa > 0 && fb > 0) || (fa < 0 && fb < 0)
+        return b, "Function sign is the same at the interval endpoints"
+    end
+    local c::T, fc::T, d::T, e::T, F1::T, F2::T
+    local iexpc::Int
+    restart = true
+    while true
+        if restart                        # label 2000: internal root
+            c, fc, iexpc = a, fa, iexpa
+            e = b - a
+            d = e
+            if iexpa < iexpb              # external root
+                F1 = fc * T(10)^(iexpc - iexpb)
+                F2 = fb
+            else
+                F1 = fc
+                F2 = fb * T(10)^(iexpb - iexpc)
+            end
+            restart = false
+        end
+        # label 3000
+        if abs(F1) < abs(F2)
+            a, b, c = b, c, b
+            fa, fb, fc = fb, fc, fb
+            iexpa, iexpb, iexpc = iexpb, iexpc, iexpb
+        end
+        tol = 2 * macheps * abs(b) + t
+        m = (c - b) / 2
+        (abs(m) > tol && fb != 0) || return b, ""
+
+        # see if a bisection is forced
+        if iexpa < iexpb
+            F1 = fa * T(10)^(iexpa - iexpb)
+            F2 = fb
+        else
+            F1 = fa
+            F2 = fb * T(10)^(iexpb - iexpa)
+        end
+        if abs(e) < tol || abs(F1) <= abs(F2)
+            e = m
+            d = e
+        else
+            s = fb / fa * T(10)^(iexpb - iexpa)
+            local p::T, q::T
+            if a == c                     # linear interpolation
+                p = 2 * m * s
+                q = 1 - s
+            else                          # inverse quadratic interpolation
+                q = fa / fc * T(10)^(iexpa - iexpc)
+                r = fb / fc * T(10)^(iexpb - iexpc)
+                p = s * (2 * m * q * (q - r) - (b - a) * (r - 1))
+                q = (q - 1) * (r - 1) * (s - 1)
+            end
+            if p > 0
+                q = -q
+            else
+                p = -p
+            end
+            s = e
+            e = d
+            if 2 * p < 3 * m * q - abs(tol * q) && p < abs(s * q / 2)
+                d = p / q
+            else
+                e = m
+                d = e
+            end
+        end
+        a, fa, iexpa = b, fb, iexpb
+        if abs(d) > tol
+            b += d
+        else
+            b += m > 0 ? tol : -tol
+        end
+        fb, iexpb = fun(b)
+        (fb > 0) == (fc > 0) && (restart = true)
+    end
+end
+
+"""
+    bisection(w, prob, xmin, xmax, M) -> (xl, xr)
+
+Sturm-sequence bisection returning an isolating interval per eigenvalue in
+[xmin, xmax] (ports `Bisection`, kraken.f90).
+"""
+function bisection(w::MeshWorkspace{T,T}, prob::Problem{T}, xmin::T, xmax::T,
+                   M::Int) where {T}
+    maxbisections = 50
+    xl = fill(xmin, M + 1)
+    xr = fill(xmax, M + 1)
+    noroots = T[]
+
+    _, _, nzer1 = funct(w, prob, xmax, noroots, 0; count_modes=true, deflate=false)
+    M == 1 && return xl, xr
+
+    for mode in 1:M-1
+        if xl[mode] == xmin
+            x2 = xr[mode]
+            x1 = max(maximum(view(xl, mode+1:M)), xmin)
+            for _ in 1:maxbisections
+                x = x1 + (x2 - x1) / 2
+                _, _, cnt = funct(w, prob, x, noroots, 0; count_modes=true,
+                                  deflate=false)
+                nzeros = cnt - nzer1
+                if nzeros < mode          # not too many zeros: new right bdry
+                    x2 = x
+                    xr[mode] = x
+                else                      # new left bdry
+                    x1 = x
+                    nzeros + 1 <= M + 1 && xr[nzeros+1] >= x && (xr[nzeros+1] = x)
+                    nzeros >= 1 && nzeros <= M + 1 && xl[nzeros] <= x && (xl[nzeros] = x)
+                end
+                xl[mode] != xmin && break
+            end
+        end
+    end
+    xl, xr
+end
+
+"""
+    solve1_real!(w, prob, evmat, iset) -> M
+
+KRAKEN's bisection + Brent solver for the first two meshes (ports `Solve1`,
+kraken.f90). Fills `evmat[iset, 1:M]` and returns M (also sizes `evmat` on
+the first mesh via the returned count — caller allocates).
+"""
+function count_modes_real(w::MeshWorkspace{T,T}, prob::Problem{T}) where {T}
+    ω² = (2π * prob.freq)^2
+    xmin = T(1.00001) * ω² / w.chigh^2
+    _, _, cnt = funct(w, prob, xmin, T[], 0; count_modes=true, deflate=false)
+    cnt
+end
+
+function solve1_real!(w::MeshWorkspace{T,T}, prob::Problem{T},
+                      evmat::Matrix{T}, iset::Int) where {T}
+    ω² = (2π * prob.freq)^2
+    xmin = T(1.00001) * ω² / w.chigh^2
+    Mtotal = count_modes_real(w, prob)
+
+    xmax = ω² / w.clow^2
+    _, _, cnt = funct(w, prob, xmax, T[], 0; count_modes=true, deflate=false)
+    M = Mtotal - cnt
+    M == 0 && error("KrakenJL: No modes for given phase speed interval")
+    M = min(M, size(evmat, 2))
+
+    xl, xr = bisection(w, prob, xmin, xmax, M)
+
+    # call ZBRENT to refine each eigenvalue in turn
+    noroots = T[]
+    for mode in 1:M
+        x1 = xl[mode]
+        x2 = xr[mode]
+        eps = abs(x2) * T(10)^(2 - precision_digits(T))
+        x, errmsg = zbrentx(x1, x2, eps, xx ->
+            (dp = funct(w, prob, xx, noroots, 0; deflate=false);
+             (dp[1], dp[2])))
+        # errmsg is a warning only in the Fortran; the root is kept either way
+        evmat[iset, mode] = x
+    end
+    M
+end
+
+# Fortran PRECISION(double) = 15
+precision_digits(::Type{Float64}) = 15
+precision_digits(::Type{T}) where {T<:Real} = floor(Int, -log10(eps(T))) - 1
+
+"""
+    solve2_real!(w, prob, evmat, hv, iset, M, deflate) -> M
+
+KRAKEN's secant solver, used for meshes ≥ 3 (or throughout when elastic
+layers are present). Ports `Solve2` (kraken.f90).
+"""
+function solve2_real!(w::MeshWorkspace{T,T}, prob::Problem{T},
+                      evmat::Matrix{T}, hv::Vector{T}, iset::Int, M::Int,
+                      deflate::Bool) where {T}
+    ω² = (2π * prob.freq)^2
+    maxiteration = 2000
+    x = ω² / w.clow^2
+    P = zeros(T, 10)
+
+    for mode in 1:M
+        x = T(1.00001) * x
+        if iset >= 2
+            for j in 1:iset-1
+                P[j] = evmat[j, mode]
+            end
+            if iset >= 3
+                for ii in 1:iset-2, j in 1:iset-ii-1
+                    x1 = hv[j]^2
+                    x2 = hv[j+ii]^2
+                    P[j] = ((hv[iset]^2 - x2) * P[j] - (hv[iset]^2 - x1) * P[j+1]) /
+                           (x1 - x2)
+                end
+                x = P[1]
+            end
+        end
+
+        tolerance = abs(x) * length(w.b1) * T(10)^(1 - precision_digits(T))
+        roots = view(evmat, iset, 1:mode-1)
+        x, errmsg = secant(x, tolerance, maxiteration, xx ->
+            (dp = funct(w, prob, xx, roots, mode - 1; deflate);
+             (dp[1], dp[2])))
+        isempty(errmsg) || (x = floatmin(T))    # make sure value is discarded
+
+        evmat[iset, mode] = x
+
+        if ω² / w.chigh^2 > x       # toss out modes outside the spectrum
+            return mode - 1
+        end
+    end
+    M
+end
+
+"""
+    solve2_complex!(w, prob, evmat, hv, iset, M, robust, rng) -> M
+
+KRAKENC's secant solver with deflation and random restarts (ports `Solve2`,
+krakenc.f90). `rng` supplies the restart randomness — a deterministic
+generator in this port (see PORTING_NOTES §3).
+"""
+function solve2_complex!(w::MeshWorkspace{T,Complex{T}}, prob::Problem{T},
+                         evmat::Matrix{Complex{T}}, hv::Vector{T}, iset::Int,
+                         M::Int, robust::Bool, rng) where {T}
+    ω = 2π * prob.freq
+    ω² = ω^2
+    maxiteration = 1000
+    x = Complex{T}(ω² / w.clow^2)
+    P = zeros(Complex{T}, 10)
+
+    maxtries = robust && iset <= 2 ? max(10, length(w.b1) ÷ 50) : 1
+    itry = 1
+    mode = 1
+    while true
+        x = T(1.00001) * x
+        if iset >= 2
+            for j in 1:iset-1
+                P[j] = evmat[j, mode]
+            end
+            if iset >= 3
+                for ii in 1:iset-2, j in 1:iset-ii-1
+                    x1 = hv[j]^2
+                    x2 = hv[j+ii]^2
+                    P[j] = ((hv[iset]^2 - x2) * P[j] - (hv[iset]^2 - x1) * P[j+1]) /
+                           (x1 - x2)
+                end
+                x = P[1]
+            end
+        end
+
+        tolerance = abs(x) * length(w.b1) * T(10)^(1 - precision_digits(T))
+        roots = view(evmat, iset, 1:mode-1)
+        x, errmsg = secant(x, tolerance, maxiteration, xx ->
+            (dp = funct(w, prob, xx, roots, mode - 1);
+             (dp[1], dp[2])))
+
+        if ω / w.chigh > real(sqrt(x)) || !isempty(errmsg)
+            # mode outside the spectral limits: restart at a random point
+            # (uniform distribution in vertical wavenumber, krakenc.f90)
+            rvar1 = rand01(rng)
+            rvar2 = rand01(rng)
+            kzhigh = ω / w.clow
+            kztry = rvar1 * kzhigh + im * T(0.01) * rvar2 * kzhigh
+            x = ω² / w.clow^2 - kztry^2
+            if itry < maxtries
+                itry += 1
+                continue
+            else
+                break
+            end
+        else
+            evmat[iset, mode] = x
+            mode += 1
+            mode > M && break
+        end
+    end
+    M = mode - 1
+    M == 0 && error("KrakenJL: No modes for given phase speed interval")
+
+    # order eigenvalues by real part (descending), Sort (misc/SortMod.f90)
+    xs = evmat[iset, 1:M]
+    sort!(xs; by=real, rev=true)
+    evmat[iset, 1:M] .= xs
+    M
+end
+
+# Deterministic substitute for the Fortran RANDOM_NUMBER in the (rare)
+# restart path — a simple xorshift64*, seeded per solve for reproducibility.
+mutable struct RestartRNG
+    state::UInt64
+end
+RestartRNG() = RestartRNG(0x9E3779B97F4A7C15)
+function rand01(rng::RestartRNG)
+    x = rng.state
+    x ⊻= x >> 12
+    x ⊻= x << 25
+    x ⊻= x >> 27
+    rng.state = x
+    Float64((x * 0x2545F4914F6CDD1D) >> 11) / Float64(1 << 53)
+end
+
+"""
+    solve_modes(prob, ngs; complex_solver=true, robust=false, threads=1)
+        -> ModeResult
+
+Top-level driver: solve the eigenproblem over a sequence of up to `NSETS`
+meshes with Richardson extrapolation (ports the main program + `Solve` of
+kraken.f90 / krakenc.f90). `ngs` are the base mesh counts per medium.
+"""
+function solve_modes(prob::Problem{T}, ngs::Vector{Int};
+                     complex_solver::Bool=true, robust::Bool=false,
+                     threads::Int=1) where {T}
+    X = complex_solver ? Complex{T} : T
+    nmedia = length(prob.media)
+    w = MeshWorkspace{T,X}(nmedia)
+    ω = 2π * prob.freq
+    ω² = ω^2
+    hv = zeros(T, NSETS)
+    rng = RestartRNG()
+
+    evmat = Matrix{X}(undef, 0, 0)
+    extrap = Matrix{X}(undef, 0, 0)
+    kpert = Complex{T}[]
+    vg = T[]
+    phi = Matrix{Complex{T}}(undef, 0, 0)
+    zmesh = T[]
+    M = 0
+    err = T(Inf)
+    no_elastic_layers = true
+
+    for iset in 1:NSETS
+        for m in 1:nmedia
+            w.n[m] = ngs[m] * NV[iset]
+            w.h[m] = (prob.media[m].z1 - prob.media[m].z0) / w.n[m]
+        end
+        hv[iset] = w.h[1]
+
+        initialize!(w, prob)
+        nacoustic = w.last_acoustic - w.first_acoustic + 1
+        no_elastic_layers = nmedia <= nacoustic
+
+        if iset == 1
+            # size the eigenvalue storage (kraken: mode count / 3000;
+            # krakenc: MaxM)
+            M0 = if complex_solver
+                MAX_MODES
+            elseif no_elastic_layers
+                max(count_modes_real(w, prob), 1)
+            else
+                3000
+            end
+            evmat = zeros(X, NSETS, M0)
+            extrap = zeros(X, NSETS, M0)
+            kpert = zeros(Complex{T}, M0)
+            vg = zeros(T, M0)
+            M = M0
+        end
+
+        # Solve for the eigenvalues on this mesh
+        if complex_solver
+            M = solve2_complex!(w, prob, evmat, hv, iset, M, robust, rng)
+        elseif iset <= 2 && no_elastic_layers
+            M = solve1_real!(w, prob, evmat, iset)
+        else
+            M = solve2_real!(w, prob, evmat, hv, iset, M, !no_elastic_layers)
+        end
+
+        extrap[iset, 1:M] .= evmat[iset, 1:M]
+
+        # Remove eigenvalues outside the spectral limits (they are sorted
+        # descending by real part, so this is the MINLOC trim of the Fortran)
+        lim = ω² / w.chigh^2
+        Mtrim = 0
+        for i in 1:M
+            real(extrap[1, i]) > lim && (Mtrim = i)
+        end
+        M = Mtrim
+        M == 0 && error("KrakenJL: No modes for given phase speed interval")
+
+        if iset == 1     # compute the eigenvectors on the first mesh
+            phi, zmesh = vector!(w, prob, evmat, kpert, vg, M, complex_solver,
+                                 threads)
+        end
+
+        # Richardson extrapolation to improve the accuracy (Solve)
+        err = T(1.0e10)
+        key = 2 * M ÷ 3 + 1
+        if iset > 1
+            t1 = extrap[1, key]
+            for j in iset-1:-1:1, mode in 1:M
+                x1 = T(NV[j])^2
+                x2 = T(NV[iset])^2
+                f1 = extrap[j, mode]
+                f2 = extrap[j+1, mode]
+                extrap[j, mode] = f2 - (f1 - f2) / (x2 / x1 - 1)
+            end
+            t2 = extrap[1, key]
+            err = abs(t2 - t1)
+        end
+
+        err * 1000 * prob.rmax < 1 && break   # convergence achieved
+    end
+
+    # discard modes with phase velocity above cHigh (final trim)
+    lim = ω² / w.chigh^2
+    Mtrim = 0
+    for i in 1:M
+        real(extrap[1, i]) > lim && (Mtrim = i)
+    end
+    M = Mtrim
+
+    # k() contains scatter/attenuation perturbations; combine with the
+    # extrapolated eigenvalues (kraken(c).f90 main)
+    k = [sqrt(Complex{T}(extrap[1, i]) + kpert[i]) for i in 1:M]
+    if complex_solver
+        # zero out positive imaginary parts which would cause growth in range
+        k = [imag(ki) > 0 ? Complex{T}(real(ki)) : ki for ki in k]
+    end
+
+    ModeResult{T}(k, phi[:, 1:M], zmesh, vg[1:M])
+end

--- a/src/krakenjl/types.jl
+++ b/src/krakenjl/types.jl
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Problem description and solver workspace. Mirrors the module variables of
+# KrakenMod.f90 / KrakencMod.f90 and the SSP structure of misc/sspMod.f90,
+# repackaged as explicit structs (no globals).
+
+# KrakenMod.f90: MaxM = 20000 (max # of modes), NSets = 5 (Richardson meshes)
+const MAX_MODES = 20000
+const NSETS = 5
+const NV = (1, 2, 4, 8, 16)          # mesh multipliers, kraken(c).f90 main
+
+# FUNCT / AcousticLayers / BCImpedance scaling constants (kraken(c).f90)
+const IPOW_R = 50
+const IPOW_F = -50
+const ROOF = 1.0e50
+const FLOOR_ = 1.0e-50
+
+"""
+Halfspace / boundary condition. Mirrors `HSInfo` (sspMod.f90) restricted to
+the codes reachable through the wrapper: 'V' vacuum, 'R' rigid, 'A'
+acousto-elastic halfspace (fluid when cs == 0).
+"""
+struct Halfspace{T<:Real}
+    bc::Symbol               # :vacuum, :rigid, :acoustoelastic
+    cp::Complex{T}           # complex compressional speed (CRCI-converted)
+    cs::Complex{T}           # complex shear speed (0 for fluid)
+    rho::T                   # density ratio (g/cm³, water = 1)
+end
+
+Halfspace{T}(bc::Symbol) where {T} =
+    Halfspace{T}(bc, zero(Complex{T}), zero(Complex{T}), zero(T))
+
+"""
+One medium (layer) of the problem. SSP nodes are CRCI-converted complex
+speeds; `spline` selects cubic-spline ('S') vs C-linear ('C') subtabulation
+(sspMod.f90 cCubic/cLinear). `ng` is the base finite-difference mesh count
+(NG in the Fortran; the auto rule of ReadEnvironmentMod is applied by the
+caller). `sigma` roughness values live in `Problem` (per interface).
+"""
+struct Medium{T<:Real}
+    z0::T                    # depth of top of medium [m]
+    z1::T                    # depth of bottom of medium [m]
+    zn::Vector{T}            # SSP node depths (ascending, zn[1]=z0, zn[end]=z1)
+    cpn::Vector{Complex{T}}  # complex P-speed at nodes
+    csn::Vector{Complex{T}}  # complex S-speed at nodes (nonzero ⇒ elastic)
+    rhon::Vector{T}          # density at nodes (g/cm³ ratio)
+    spline::Bool
+    ng::Int
+end
+
+is_elastic(m::Medium) = any(!iszero, m.csn)
+
+"Range-independent normal-mode problem (one profile, one frequency)."
+struct Problem{T<:Real}
+    freq::T
+    media::Vector{Medium{T}}
+    sigma::Vector{T}         # interface roughness, length nmedia+1 (top..bottom)
+    hstop::Halfspace{T}
+    hsbot::Halfspace{T}
+    clow::T                  # phase-speed search interval
+    chigh::T
+    rmax::T                  # max range [m] for the Richardson convergence test
+end
+
+"""
+Finite-difference workspace for one mesh (one `iSet`). Mirrors the module
+arrays of Kraken(c)Mod.f90. `X` is the arithmetic type of the characteristic
+function: `Complex{T}` for KRAKENC, `T` for KRAKEN (which keeps the imaginary
+part of ω²/c² separately in `b1c`).
+"""
+mutable struct MeshWorkspace{T<:Real,X<:Number}
+    n::Vector{Int}           # mesh intervals per medium
+    h::Vector{T}             # mesh spacing per medium
+    loc::Vector{Int}         # offset of each medium in the point arrays
+    b1::Vector{X}            # FD diagonal (acoustic) / elastic coefficient
+    b1c::Vector{T}           # KRAKEN only: imag(ω²/c²) for the perturbation
+    b2::Vector{X}            # elastic coefficients (kraken(c).f90 Initialize)
+    b3::Vector{X}
+    b4::Vector{X}
+    rho::Vector{T}
+    first_acoustic::Int
+    last_acoustic::Int
+    cmin::T
+    clow::T                  # search interval after the cmin adjustments
+    chigh::T
+end
+
+function MeshWorkspace{T,X}(nmedia::Int) where {T,X}
+    MeshWorkspace{T,X}(zeros(Int, nmedia), zeros(T, nmedia), zeros(Int, nmedia),
+                       X[], T[], X[], X[], X[], T[], 0, 0, zero(T), zero(T),
+                       zero(T))
+end
+
+"Result of the mode solve: everything the API layer needs."
+struct ModeResult{T<:Real}
+    k::Vector{Complex{T}}    # modal wavenumbers (perturbed, sorted)
+    phi::Matrix{Complex{T}}  # mode shapes on the solver mesh (NTotal1 × M)
+    z::Vector{T}             # mesh depths for phi (acoustic media only)
+    vg::Vector{T}            # group speeds (0 when invalid — KRAKEN real path)
+end

--- a/test/test_krakenjl.jl
+++ b/test/test_krakenjl.jl
@@ -1,0 +1,130 @@
+using TestItems
+
+# Tests for the KrakenJL solver (src/krakenjl/, GPL-3.0-or-later).
+# Golden reference constants below were generated from the Fortran Kraken
+# (AcousticsToolbox_jll, OALIB 2024_12_25 build) via the Kraken wrapper in
+# this package.
+
+@testitem "krakenjl-models" begin
+  using UnderwaterAcoustics
+  m = models()
+  @test KrakenJL ∈ m
+  env = UnderwaterEnvironment(bathymetry = 20.0u"m")
+  pm = KrakenJL(env)
+  @test pm isa KrakenJL
+  @test_throws ErrorException KrakenJL(env; nmodes = 0)
+  @test_throws ErrorException KrakenJL(env; mesh_density = -1)
+  @test_throws ErrorException KrakenJL(env; clow = 2000.0, chigh = 1500.0)
+  @test_throws ErrorException KrakenJL(env; threads = 0)
+end
+
+@testitem "krakenjl-pekeris-modes" begin
+  using UnderwaterAcoustics
+  # mirrors test_kraken.jl "kraken-pekeris-modes"
+  env = UnderwaterEnvironment(
+    bathymetry = 5000.0,
+    soundspeed = 1500.0,
+    density = 1000.0,
+    seabed = FluidBoundary(2000.0, 2000.0)
+  )
+  tx = AcousticSource(0.0, -500.0, 10.0)
+  rx = AcousticReceiver(200000.0, -2500.0)
+  rxs = AcousticReceiverGrid2D(200000.0:10.0:220000.0, -2500.0)
+  pm = PekerisModeSolver(env)
+  arr = arrivals(pm, tx, rx)
+  x = transmission_loss(pm, tx, rxs)
+  for complex_solver ∈ [false, true]
+    pm1 = KrakenJL(env; chigh=2000.0, complex_solver)
+    arr1 = arrivals(pm1, tx, rx)
+    @test arr1 isa AbstractArray{<:UnderwaterAcoustics.ModeArrival}
+    @test length(arr1) == length(arr)
+    @test [a.kᵣ for a ∈ arr1] ≈ [a.kᵣ for a ∈ arr] atol=0.001
+    x1 = transmission_loss(pm1, tx, rxs)
+    @test size(x1) == size(x)
+    @test sum(abs, x1 .- x) / length(x) < 1
+  end
+  # KRAKENC group speeds should be physical; KRAKEN (real) reports zeros
+  arrc = arrivals(KrakenJL(env; chigh=2000.0), tx, rx)
+  @test all(0 .< [a.v for a ∈ arrc] .< 1500.0)
+  arrr = arrivals(KrakenJL(env; chigh=2000.0, complex_solver=false), tx, rx)
+  @test all(iszero, [a.v for a ∈ arrr])
+end
+
+@testitem "krakenjl-golden" begin
+  using UnderwaterAcoustics
+  # golden (Fortran Kraken, complex_solver=true) references
+  env = UnderwaterEnvironment(bathymetry = 5000.0, soundspeed = 1500.0,
+    density = 1000.0, seabed = FluidBoundary(2000.0, 2000.0))
+  tx = AcousticSource(0.0, -500.0, 10.0)
+  arr = arrivals(KrakenJL(env; chigh=2000.0), tx, AcousticReceiver(200000.0, -2500.0))
+  @test length(arr) == 44
+  @test real(arr[1].kᵣ) ≈ 0.041883323 atol=1e-7
+  @test real(arr[2].kᵣ) ≈ 0.041869581 atol=1e-7
+  @test real(arr[10].kᵣ) ≈ 0.041426945 atol=1e-7
+  @test real(arr[44].kᵣ) ≈ 0.031728230 atol=1e-7
+  @test imag(arr[1].kᵣ) ≈ -7.119e-10 rtol=0.01
+  rxs = AcousticReceiverGrid2D(200000.0:10.0:220000.0, -2500.0)
+  x = transmission_loss(KrakenJL(env; chigh=2000.0), tx, rxs)
+  @test x[1] ≈ 93.2741 atol=0.1
+  @test x[500] ≈ 86.6302 atol=0.1
+  @test x[2001] ≈ 95.2300 atol=0.1
+  # lossy elastic seabed (KRAKENC only; the real KRAKEN caps chigh at the
+  # shear speed and finds no modes, as the Fortran does)
+  env2 = UnderwaterEnvironment(bathymetry = 100.0, soundspeed = 1500.0,
+    seabed = ElasticBoundary(2000.0, 1800.0, 400.0, 0.1, 0.2))
+  tx2 = AcousticSource(0.0, -25.0, 300.0)
+  arr2 = arrivals(KrakenJL(env2), tx2, AcousticReceiver(3000.0, -60.0))
+  @test length(arr2) == 32
+  @test real(arr2[1].kᵣ) ≈ 1.256259322 atol=1e-6
+  @test imag(arr2[1].kᵣ) ≈ -6.218312e-6 rtol=0.01
+  rxs2 = AcousticReceiverGrid2D(1000.0:10.0:3000.0, -60.0)
+  x2 = transmission_loss(KrakenJL(env2), tx2, rxs2)
+  @test x2[1] ≈ 61.1224 atol=0.1
+  @test x2[100] ≈ 64.9941 atol=0.1
+  @test x2[201] ≈ 58.1588 atol=0.1
+end
+
+@testitem "krakenjl-vs-kraken" begin
+  using UnderwaterAcoustics
+  using Statistics
+  # multilayer elastic seabed and spline SSP, cross-checked at runtime
+  env1 = UnderwaterEnvironment(bathymetry = 100.0, soundspeed = 1500.0,
+    seabed = MultilayerElasticBoundary([
+      (h=20.0, ρ=1500.0, cₚ=1600.0, cₛ=200.0, δₚ=0.1, δₛ=0.2),
+      (h=Inf, ρ=2000.0, cₚ=1800.0, cₛ=400.0, δₚ=0.1, δₛ=0.2)]))
+  tx1 = AcousticSource(0.0, -25.0, 300.0)
+  rxs1 = AcousticReceiverGrid2D(1000.0:10.0:3000.0, -60.0)
+  munk(z) = 1500 * (1 + 0.00737 * (2 * (z - 1300) / 1300 - 1 + exp(-2 * (z - 1300) / 1300)))
+  zvals = 0.0:250.0:5000.0
+  env2 = UnderwaterEnvironment(bathymetry = 5000.0,
+    soundspeed = SampledField(munk.(zvals); z=-zvals, interp=CubicSpline()),
+    seabed = FluidBoundary(1900.0, 1650.0, 0.1))
+  tx2 = AcousticSource(0.0, -1000.0, 50.0)
+  rxs2 = AcousticReceiverGrid2D(10000.0:100.0:60000.0, -1000.0)
+  for (env, tx, rxs) ∈ [(env1, tx1, rxs1), (env2, tx2, rxs2)]
+    x1 = transmission_loss(KrakenJL(env), tx, rxs)
+    x2 = transmission_loss(Kraken(env), tx, rxs)
+    @test median(abs.(x1 .- x2)) < 0.1
+    y1 = transmission_loss(KrakenJL(env), tx, rxs; mode=:incoherent)
+    y2 = transmission_loss(Kraken(env), tx, rxs; mode=:incoherent)
+    @test median(abs.(y1 .- y2)) < 0.1
+  end
+end
+
+@testitem "krakenjl-threads" begin
+  using UnderwaterAcoustics
+  # serial vs threaded results must be identical: each mode / range column is
+  # written by exactly one task, so there is no reduction reordering
+  env = UnderwaterEnvironment(bathymetry = 5000.0, soundspeed = 1500.0,
+    density = 1000.0, seabed = FluidBoundary(2000.0, 2000.0))
+  tx = AcousticSource(0.0, -500.0, 10.0)
+  rxs = AcousticReceiverGrid2D(200000.0:100.0:220000.0, -4900.0:100.0:-100.0)
+  x1 = acoustic_field(KrakenJL(env; chigh=2000.0, threads=1), tx, rxs)
+  x4 = acoustic_field(KrakenJL(env; chigh=2000.0, threads=4), tx, rxs)
+  @test x1 == x4
+  @test x4 == acoustic_field(KrakenJL(env; chigh=2000.0, threads=4), tx, rxs)
+  a1 = arrivals(KrakenJL(env; chigh=2000.0, threads=1), tx, AcousticReceiver(200000.0, -2500.0))
+  a4 = arrivals(KrakenJL(env; chigh=2000.0, threads=4), tx, AcousticReceiver(200000.0, -2500.0))
+  @test [a.kᵣ for a ∈ a1] == [a.kᵣ for a ∈ a4]
+  @test all([a1[i].ψ(-100.0) == a4[i].ψ(-100.0) for i ∈ eachindex(a1)])
+end

--- a/test/test_krakenjl.jl
+++ b/test/test_krakenjl.jl
@@ -128,3 +128,35 @@ end
   @test [a.kᵣ for a ∈ a1] == [a.kᵣ for a ∈ a4]
   @test all([a1[i].ψ(-100.0) == a4[i].ψ(-100.0) for i ∈ eachindex(a1)])
 end
+
+@testitem "∂krakenjl" begin
+  using UnderwaterAcoustics
+  using ForwardDiff
+  using FiniteDifferences
+  # gradient of TL w.r.t. bathymetry, range, source/receiver depth, frequency
+  # and sound speed; generic values avoid mesh-node/integer-depth kinks where
+  # the finite-difference reference straddles model discontinuities
+  function ℳ(x)
+    D, R, d1, d2, f, c = x
+    env = UnderwaterEnvironment(bathymetry=D, soundspeed=c, density=1000.0,
+                                seabed=FluidBoundary(2000.0, 2000.0))
+    pm = KrakenJL(env; chigh=2000.0)
+    transmission_loss(pm, AcousticSource(0.0, -d1, f), AcousticReceiver(R, -d2))
+  end
+  x0 = [4987.3, 199234.7, 511.4, 2483.9, 10.3, 1501.7]
+  g1 = ForwardDiff.gradient(ℳ, x0)
+  g2 = FiniteDifferences.grad(central_fdm(5, 1), ℳ, x0)[1]
+  @test g1 ≈ g2 rtol=1e-3
+  # real (KRAKEN) solver, seabed parameters
+  function ℳ2(x)
+    cb, ρb, δb = x
+    env = UnderwaterEnvironment(bathymetry=4987.3, soundspeed=1500.0, density=1000.0,
+                                seabed=FluidBoundary(ρb, cb, δb))
+    pm = KrakenJL(env; chigh=1999.0, complex_solver=false)
+    transmission_loss(pm, AcousticSource(0.0, -511.4, 10.3), AcousticReceiver(199234.7, -2483.9))
+  end
+  y0 = [2000.0, 2000.0, 0.1]
+  h1 = ForwardDiff.gradient(ℳ2, y0)
+  h2 = FiniteDifferences.grad(central_fdm(5, 1), ℳ2, y0)[1]
+  @test h1 ≈ h2 rtol=1e-3
+end


### PR DESCRIPTION
## Summary

Native Julia port of the KRAKEN / KRAKENC normal-mode models in `src/krakenjl/`, following the BellhopJL port's conventions — a drop-in `AbstractModePropagationModel` alternative to the Fortran-wrapping `Kraken` model, with no file I/O.

- **Sources**: OALIB Acoustics Toolbox **2024_12_25** (sha256-verified — the exact tree the `AcousticsToolbox_jll` 2025.9.6 binaries are built from). ORCA sources not consulted (ARL:UT license).
- **Solvers**: KRAKENC complex secant with deflation (default) and KRAKEN real Sturm-bisection + Brent; Richardson extrapolation over up to 5 meshes; perturbational attenuation, Kuperman–Ingenito interfacial scatter, group speeds.
- **Environments**: fluid / elastic / multilayer-elastic seabeds, vacuum/rigid/acousto-elastic surface, C-linear and cubic-spline SSPs, dB/λ + Francois-Garrison attenuation — mirroring the wrapper's env conversions verbatim.
- **Native mode summation** replacing `field.exe` (coherent/incoherent, `cis(-kᵣR)` convention with the wrapper's conj/negation post-processing).
- **Multithreading**: `threads` kwarg (default `Threads.nthreads()`); modes and range columns are chunked with disjoint writes, so threaded results are **bit-identical** to serial.
- **ForwardDiff**: eigenvalue search runs on values; each root is made dual-exact with one Newton step of the undeflated characteristic function in dual arithmetic (implicit function theorem); everything downstream re-runs with duals. Gradients verified against 5-point central differences to ~1e-5 relative, both solvers.
- **Licensing**: `src/krakenjl/**` is GPL-3.0-or-later with SPDX headers (derivative of GPL KRAKEN); README licensing section updated. Lineage and every intentional deviation documented in `src/krakenjl/PORTING_NOTES.md`.

## Accuracy vs Fortran Kraken (runtime cross-checks)

| Scenario | mean \|ΔTL\| |
|---|---|
| Pekeris (10 Hz, 44 modes, 200–220 km) | 0.003 dB |
| Lossy elastic seabed (300 Hz) | 0.0004 dB |
| Munk spline SSP (50 Hz) | 0.002 dB |

kᵣ matches `PekerisModeSolver` to 1e-8. Known faithful behavior: the real solver on an elastic seabed reports "No modes for given phase speed interval" exactly as the Fortran does.

## Performance (Pekeris, Apple Silicon)

| Case | KrakenJL t=1 | KrakenJL t=8 | Fortran wrapper |
|---|---|---|---|
| arrivals (mode solve) | 5.6 ms | — | 11.6 ms |
| TL field 201×49 | 6.1 ms | 5.3 ms | 15.5–19.7 ms |
| TL field 2191×499 | 37.3 ms | — | 54.7 ms |

## Test plan

- [x] 578/578 tests at `-t 4` and single-threaded with `--check-bounds=yes`
- [x] New testitems: registration/validation, Pekeris cross-check (both solvers), Fortran golden values (Pekeris + lossy elastic), runtime vs-Kraken (multilayer elastic + Munk spline, coherent & incoherent), thread determinism (bitwise), ∂krakenjl AD vs FiniteDifferences